### PR TITLE
DEV-44180 - Changes for alert eval

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1223,8 +1223,10 @@ state_periodic_save_interval = 5m
 # Rules will evaluate in sync.
 disable_jitter = false
 
+# LOGZ.IO GRAFANA CHANGE :: DEV-43889, DEV-44180 Grafana alerts evaluation
 # The url set to send alerts for external notifications on the LogzioAlertsRouter. If you put empty string it will not send, only log.
 logzio_alerts_route_url =
+
 
 [unified_alerting.screenshots]
 # Enable screenshots in notifications. You must have either installed the Grafana image rendering

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1223,6 +1223,9 @@ state_periodic_save_interval = 5m
 # Rules will evaluate in sync.
 disable_jitter = false
 
+# The url set to send alerts for external notifications on the LogzioAlertsRouter. If you put empty string it will not send, only log.
+logzio_alerts_route_url =
+
 [unified_alerting.screenshots]
 # Enable screenshots in notifications. You must have either installed the Grafana image rendering
 # plugin, or set up Grafana to use a remote rendering service.

--- a/pkg/services/ngalert/api/alerting_logzio.go
+++ b/pkg/services/ngalert/api/alerting_logzio.go
@@ -51,7 +51,7 @@ func (srv *LogzioAlertingService) RouteEvaluateAlert(c *contextmodel.ReqContext,
 			AlertRule:   evalRequest.AlertRule,
 			EvalTime:    evalRequest.EvalTime,
 			FolderTitle: evalRequest.FolderTitle,
-			LogzHeaders: c.Req.Header,
+			LogzHeaders: srv.addQuerySourceHeader(c),
 		}
 		err := srv.Schedule.RunRuleEvaluation(c.Req.Context(), evalReq)
 
@@ -64,6 +64,12 @@ func (srv *LogzioAlertingService) RouteEvaluateAlert(c *contextmodel.ReqContext,
 
 	c.Logger.Info("Evaluate Alert API - Done", "evalErrors", evaluationsErrors)
 	return response.JSON(http.StatusOK, apimodels.EvalRunsResponse{RunResults: evaluationsErrors})
+}
+
+func (srv *LogzioAlertingService) addQuerySourceHeader(c *contextmodel.ReqContext) http.Header {
+	requestHeaders := c.Req.Header
+	requestHeaders.Set("Query-Source", "METRICS_ALERTS")
+	return requestHeaders
 }
 
 func (srv *LogzioAlertingService) RouteSendAlertNotifications(c *contextmodel.ReqContext, sendNotificationsRequest apimodels.AlertSendNotificationsRequest) response.Response {

--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -294,7 +294,13 @@ func (c *baseClientImpl) getMultiSearchQueryParameters() string {
 	if headers != nil {
 		querySourceFromLogzHeaders = headers["Query-Source"]
 		if len(querySourceFromLogzHeaders) > 0 {
-			qs = append(qs, fmt.Sprintf("querySource=%s", querySourceFromLogzHeaders[0]))
+			var qsToAdd string
+			if querySourceFromLogzHeaders[0] == "METRICS_ALERTS" {
+				qsToAdd = "INTERNAL_METRICS_ALERTS"
+			} else {
+				qsToAdd = querySourceFromLogzHeaders[0]
+			}
+			qs = append(qs, fmt.Sprintf("querySource=%s", qsToAdd))
 		}
 	}
 


### PR DESCRIPTION
**What is this feature?**

Changes required for logz alert evaluation integration:
* Added the logzio_alerts_route_url in defaults.ini so it can be configured as part of the image variables, instead of custom.ini file, as it is based on environment
* Added metrics alerts Query-Source header in the alert evaluation api.
* In elasticsearch client fix to send the correct querySource


**Why do we need this feature?**
Alert evaluation in logz

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
