### PR TITLE
Fix

### DIFF
--- a/public/app/core/copy/appNotification.ts
+++ b/public/app/core/copy/appNotification.ts
@@ -47,7 +47,7 @@ export const createErrorNotification = (
   const logzLogger = logzioServices.LoggerService;
   logzLogger.logError({
     origin: logzLogger.Origin.GRAFANA,
-    message: getMessageFromError(text),
+  message: getMessageFromError(text) || title || 'Unknown error from metrics product', // DEV-45291 - use title if message is empty string
     error: null,
     uxType: logzLogger.UxType.TOAST,
     extra: {


### PR DESCRIPTION
If the error handler is called with the empty string all the flow fails at `error.message` later in the logzioLogger.