### PR TITLE
Strip path part

### DIFF
--- a/public/app/features/alerting/unified/utils/url.ts
+++ b/public/app/features/alerting/unified/utils/url.ts
@@ -4,7 +4,7 @@ export function createUrl(path: string, queryParams?: string[][] | Record<string
   const searchParams = new URLSearchParams(queryParams);
   const searchParamsString = searchParams.toString();
 
-  return `${config.appSubUrl}${path}${searchParamsString ? `?${searchParamsString}` : ''}`;
+  return `${path}${searchParamsString ? `?${searchParamsString}` : ''}`;
 }
 
 export function createAbsoluteUrl(


### PR DESCRIPTION
the frontend links are built with redundant `grafana-app` part which leads to 404 on front.
