### PR TITLE
DEV-43349 Grafana upgrade leftovers and fixes::Fix shapshots url in App

### DIFF
--- a/public/app/core/components/PageNotFound/EntityNotFound.tsx
+++ b/public/app/core/components/PageNotFound/EntityNotFound.tsx
@@ -23,10 +23,10 @@ export function EntityNotFound({ entity = 'Page' }: Props) {
         <a href="/" className="external-link">
           home
         </a>{' '}
-        or seeking help on the{' '}
+        {/* or seeking help on the{' '} LOGZ.IO GRAFANA CHANGE::DEV-00000 hide grafana links
         <a href="https://community.grafana.com" target="_blank" rel="noreferrer" className="external-link">
           community site.
-        </a>
+        </a> */}
       </div>
       <div className={styles.grot}>
         <img src={`public/img/grot-404-${theme.isDark ? 'dark' : 'light'}.svg`} width="100%" alt="grot" />

--- a/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
@@ -114,6 +114,7 @@ export class ShareSnapshot extends PureComponent<Props, State> {
       // LOGZ.IO GRAFANA CHANGE :: DEV-20896 Change snapshot url to logzio
       const logzioUrl = await logzioServices?.shareUrlService?.getLogzioGrafanaUrl({
         productUrl: window.location.origin,
+        hash: '/dashboard/grafana-snapshot',
       });
 
       this.setState({

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -363,56 +363,57 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     // LOGIN / SIGNUP
-    {
-      path: '/login',
-      component: LoginPage,
-      pageClass: 'login-page',
-      chromeless: true,
-    },
-    {
-      path: '/invite/:code',
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "SignupInvited" */ 'app/features/invites/SignupInvited')
-      ),
-      chromeless: true,
-    },
-    {
-      path: '/verify',
-      component: !config.verifyEmailEnabled
-        ? () => <Redirect to="/signup" />
-        : SafeDynamicImport(
-            () => import(/* webpackChunkName "VerifyEmailPage"*/ 'app/core/components/Signup/VerifyEmailPage')
-          ),
-      pageClass: 'login-page',
-      chromeless: true,
-    },
-    {
-      path: '/signup',
-      component: config.disableUserSignUp
-        ? () => <Redirect to="/login" />
-        : SafeDynamicImport(() => import(/* webpackChunkName "SignupPage"*/ 'app/core/components/Signup/SignupPage')),
-      pageClass: 'login-page',
-      chromeless: true,
-    },
-    {
-      path: '/user/password/send-reset-email',
-      chromeless: true,
-      component: SafeDynamicImport(
-        () =>
-          import(/* webpackChunkName: "SendResetMailPage" */ 'app/core/components/ForgottenPassword/SendResetMailPage')
-      ),
-    },
-    {
-      path: '/user/password/reset',
-      component: SafeDynamicImport(
-        () =>
-          import(
-            /* webpackChunkName: "ChangePasswordPage" */ 'app/core/components/ForgottenPassword/ChangePasswordPage'
-          )
-      ),
-      pageClass: 'login-page',
-      chromeless: true,
-    },
+    // LOGZ.IO GRAFANA CHANGE::DEV-00000 deactivate all login/signup related pages
+    // {
+    //   path: '/login',
+    //   component: LoginPage,
+    //   pageClass: 'login-page',
+    //   chromeless: true,
+    // },
+    // {
+    //   path: '/invite/:code',
+    //   component: SafeDynamicImport(
+    //     () => import(/* webpackChunkName: "SignupInvited" */ 'app/features/invites/SignupInvited')
+    //   ),
+    //   chromeless: true,
+    // },
+    // {
+    //   path: '/verify',
+    //   component: !config.verifyEmailEnabled
+    //     ? () => <Redirect to="/signup" />
+    //     : SafeDynamicImport(
+    //         () => import(/* webpackChunkName "VerifyEmailPage"*/ 'app/core/components/Signup/VerifyEmailPage')
+    //       ),
+    //   pageClass: 'login-page',
+    //   chromeless: true,
+    // },
+    // {
+    //   path: '/signup',
+    //   component: config.disableUserSignUp
+    //     ? () => <Redirect to="/login" />
+    //     : SafeDynamicImport(() => import(/* webpackChunkName "SignupPage"*/ 'app/core/components/Signup/SignupPage')),
+    //   pageClass: 'login-page',
+    //   chromeless: true,
+    // },
+    // {
+    //   path: '/user/password/send-reset-email',
+    //   chromeless: true,
+    //   component: SafeDynamicImport(
+    //     () =>
+    //       import(/* webpackChunkName: "SendResetMailPage" */ 'app/core/components/ForgottenPassword/SendResetMailPage')
+    //   ),
+    // },
+    // {
+    //   path: '/user/password/reset',
+    //   component: SafeDynamicImport(
+    //     () =>
+    //       import(
+    //         /* webpackChunkName: "ChangePasswordPage" */ 'app/core/components/ForgottenPassword/ChangePasswordPage'
+    //       )
+    //   ),
+    //   pageClass: 'login-page',
+    //   chromeless: true,
+    // },
     {
       path: '/dashboard/snapshots',
       component: SafeDynamicImport(


### PR DESCRIPTION
During the code migration from 85 one miserable line of code was missed. Due to this the final snapshot URL in the G! ui led to default G! view. While it should strip all the controls from the UI while visiting the snapshot URL.
Now, after historical justice has been restored, the snapshot url will open the minimal G! UI. Just like in the current v85.
