### PR TITLE
DEV-46209 - Fix evaluation headers concurrency issue

### DIFF
--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/expr/classic"
 	"github.com/grafana/grafana/pkg/expr/mathexp"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models" // LOGZ.IO GRAFANA CHANGE :: DEV-43889 - Add headers for logzio datasources support
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
@@ -353,7 +354,7 @@ func (dn *DSNode) Execute(ctx context.Context, now time.Time, _ mathexp.Vars, s 
 	for k, v := range req.Headers {
 		logzHeaders[k] = []string{v}
 	}
-	ctxWithLogzio := context.WithValue(ctx, "logzioHeaders", logzHeaders)
+	ctxWithLogzio := models.WithLogzHeaders(ctx, logzHeaders)
 
 	resp, err := s.dataService.QueryData(ctxWithLogzio, req)
 	// LOGZ.IO GRAFANA CHANGE :: End

--- a/pkg/models/headers_logzio.go
+++ b/pkg/models/headers_logzio.go
@@ -2,6 +2,7 @@
 package models
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 )
@@ -10,10 +11,21 @@ type LogzIoHeaders struct {
 	RequestHeaders http.Header
 }
 
+type logzHeaders struct{}
+
 var logzioHeadersWhitelist = []string{
 	"user-context",
 	"X-Logz-Query-Context",
 	"Query-Source",
+}
+
+func WithLogzHeaders(ctx context.Context, requestHeaders http.Header) context.Context {
+	return context.WithValue(ctx, logzHeaders{}, &LogzIoHeaders{RequestHeaders: requestHeaders})
+}
+
+func LogzIoHeadersFromContext(ctx context.Context) (*LogzIoHeaders, bool) {
+	key, ok := ctx.Value(logzHeaders{}).(*LogzIoHeaders)
+	return key, ok
 }
 
 func (logzioHeaders *LogzIoHeaders) GetDatasourceQueryHeaders(grafanaGeneratedHeaders http.Header) http.Header {

--- a/pkg/services/ngalert/api/alerting_logzio.go
+++ b/pkg/services/ngalert/api/alerting_logzio.go
@@ -45,7 +45,7 @@ func (srv *LogzioAlertingService) RouteEvaluateAlert(c *contextmodel.ReqContext,
 	var evaluationsErrors []apimodels.AlertEvalRunResult
 
 	for _, evalRequest := range evalRequests {
-		c.Logger.Info("Evaluate Alert API", "evalTime", evalRequest.EvalTime, "ruleTitle", evalRequest.AlertRule.Title, "ruleUID", evalRequest.AlertRule.UID)
+		c.Logger.Info("Evaluate Alert API", "eval_time", evalRequest.EvalTime, "rule_title", evalRequest.AlertRule.Title, "rule_uid", evalRequest.AlertRule.UID, "org_id", evalRequest.AlertRule.OrgID)
 
 		evalReq := ngmodels.ExternalAlertEvaluationRequest{
 			AlertRule:   evalRequest.AlertRule,
@@ -67,7 +67,7 @@ func (srv *LogzioAlertingService) RouteEvaluateAlert(c *contextmodel.ReqContext,
 }
 
 func (srv *LogzioAlertingService) addQuerySourceHeader(c *contextmodel.ReqContext) http.Header {
-	requestHeaders := c.Req.Header
+	requestHeaders := c.Req.Header.Clone()
 	requestHeaders.Set("Query-Source", "METRICS_ALERTS")
 	return requestHeaders
 }

--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -73,13 +73,9 @@ var NewClient = func(ctx context.Context, ds *DatasourceInfo, timeRange backend.
 	logger.Debug("Creating new client", "configuredFields", fmt.Sprintf("%#v", ds.ConfiguredFields), "indices", strings.Join(indices, ", "), "interval", ds.Interval, "index", ds.Database)
 
 	// LOGZ.IO GRAFANA CHANGE :: DEV-43883 - add LogzIoHeaders
-	logzIoHeaders := &models.LogzIoHeaders{}
-	headers := ctx.Value("logzioHeaders")
-	if headers != nil {
-		logzIoHeaders.RequestHeaders = http.Header{}
-		for k, v := range headers.(http.Header) {
-			logzIoHeaders.RequestHeaders[k] = v
-		}
+	logzIoHeaders, ok := models.LogzIoHeadersFromContext(ctx)
+	if !ok {
+		logzIoHeaders = &models.LogzIoHeaders{}
 	}
 	// LOGZ.IO GRAFANA CHANGE :: End
 

--- a/pkg/tsdb/prometheus/client/client.go
+++ b/pkg/tsdb/prometheus/client/client.go
@@ -169,14 +169,8 @@ func createRequest(ctx context.Context, method string, u *url.URL, bodyReader io
 
 	// LOGZ.IO GRAFANA CHANGE :: DEV-43889 - Add headers for logzio datasources support
 	logger := log.New(ctx)
-	logzHeaders := ctx.Value("logzioHeaders")
-	if logzHeaders != nil {
-		logzIoHeaders := &m.LogzIoHeaders{}
-		logzIoHeaders.RequestHeaders = http.Header{}
-		for k, v := range logzHeaders.(http.Header) {
-			logzIoHeaders.RequestHeaders[k] = v
-		}
-
+	logzIoHeaders, ok := m.LogzIoHeadersFromContext(ctx)
+	if ok {
 		request.Header = logzIoHeaders.GetDatasourceQueryHeaders(request.Header)
 	}
 	if request.Header.Get("Query-Source") == "" {


### PR DESCRIPTION
**What is this feature?**
This is a fix to bug introduced on the code adding logzio headers to the alert evaluation.
We got the exception of:  `fatal error: concurrent map iteration and map write` that was crashing the service.
This happened more often the more alert rules were evaluated at the same time, and the exception was originating at the following place in eval.go : 321
![image](https://github.com/user-attachments/assets/bfceedd3-a023-4ac4-98be-8b800d57cf8e)

The error means that the map object (the headers) had access and write operations at the same time.

**Root Cause**
The root cause for this is that the headers were added from the api request context and since the evaluate API is done in bulk for multiple alert rules at the same time, they were sharing the same headers object - which is passed as reference into the evaluation.
<img width="489" alt="image" src="https://github.com/user-attachments/assets/bb018dc5-545a-44da-9ab6-513cca54554c">
<img width="601" alt="image" src="https://github.com/user-attachments/assets/54226274-539e-47b1-992e-13c363c570ed">


**What Was the Fix?**
To fix the concurrency issue of accessing the same object we needed to clone it.
So instead of passing same headers reference we just cloned it to be a separate reference for each alert evaluation that is sent.
<img width="451" alt="image" src="https://github.com/user-attachments/assets/2aca5a74-f88e-46ed-a0ca-ede77cc76342">


** Also added the following changes:**
* small refactor on how headers are built based on similar existing code
* added / changed logs to contain rule and org information for easier investigations
* removed in eval.go some redundant logz changes (reverted to original code)


**Why do we need this feature?**
The obvious reason - server should not crash because of error when running multiple alert evaluations.
We need to support big scale and evaluation of a lot of alerts a the same time.

