### PR TITLE
DEV-46515 Auto migrate pichart panel

### DIFF
--- a/custom.ini
+++ b/custom.ini
@@ -88,3 +88,4 @@ custom_endpoint = log
 [feature_toggles]
 prometheusPromQAIL = false
 publicDashboards = false
+autoMigratePiechartPanel = true


### PR DESCRIPTION
Enabled feature toggle: `autoMigratePiechartPanel`

To support deprecated panel `grafana-piechart-panel ` as part of migration of existing accounts,
we need to upgrade to supported version `piechart`
the feature toggle allows migrating to new version panel "seamlessly" in the UI so the user will not see errors.

This is not a long-term solution, since the dashboards will not be updated without an explicit save. we will want to upgrade the dashboards eventually so there will be no deprecated type eventually , but the feature toggle allows us to migrate more easily with no time pressure.