### PR TITLE
DEV-47346-extract-grafana-evaluation-into-goroutine

### DIFF
--- a/pkg/services/ngalert/api/alerting_logzio.go
+++ b/pkg/services/ngalert/api/alerting_logzio.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 	"net/http"
 	"context"
+	"time"
 )
 
 type LogzioAlertingService struct {
@@ -56,9 +57,11 @@ func (srv *LogzioAlertingService) RouteEvaluateAlert(c *contextmodel.ReqContext,
 			LogzHeaders: srv.addQuerySourceHeader(c),
 		}
 
-		go func(ctx context.Context, request ngmodels.ExternalAlertEvaluationRequest) {
-			srv.Schedule.RunRuleEvaluation(ctx, request)
-		}(c.Req.Context(), evalReq)
+		var step = evalRequest.AlertRule.ID % 30
+
+		time.AfterFunc(time.Duration(step * time.Second.Nanoseconds()), func() {
+			srv.Schedule.RunRuleEvaluation(c.Req.Context(), evalReq)
+		})
 
 		results = append(results, apimodels.AlertEvalRunResult{UID: evalRequest.AlertRule.UID, EvalTime: evalRequest.EvalTime, RunResult: "success"})
 	}

--- a/pkg/services/ngalert/api/alerting_logzio.go
+++ b/pkg/services/ngalert/api/alerting_logzio.go
@@ -43,7 +43,8 @@ func NewLogzioAlertingService(
 
 func (srv *LogzioAlertingService) RouteEvaluateAlert(c *contextmodel.ReqContext, evalRequests []apimodels.AlertEvaluationRequest) response.Response {
 	c.Logger.Info(fmt.Sprintf("Evaluate Alert API: got requests for %d evaluations", len(evalRequests)))
-	var evaluationsErrors []apimodels.AlertEvalRunResult
+
+	var results []apimodels.AlertEvalRunResult
 
 	for _, evalRequest := range evalRequests {
 		c.Logger.Info("Evaluate Alert API", "eval_time", evalRequest.EvalTime, "rule_title", evalRequest.AlertRule.Title, "rule_uid", evalRequest.AlertRule.UID, "org_id", evalRequest.AlertRule.OrgID)
@@ -58,10 +59,12 @@ func (srv *LogzioAlertingService) RouteEvaluateAlert(c *contextmodel.ReqContext,
 		go func(ctx context.Context, request ngmodels.ExternalAlertEvaluationRequest) {
 			srv.Schedule.RunRuleEvaluation(ctx, request)
 		}(c.Req.Context(), evalReq)
+
+		results = append(results, apimodels.AlertEvalRunResult{UID: evalRequest.AlertRule.UID, EvalTime: evalRequest.EvalTime, RunResult: "success"})
 	}
 
-	c.Logger.Info("Evaluate Alert API - Done", "evalErrors", evaluationsErrors)
-	return response.JSON(http.StatusOK, apimodels.EvalRunsResponse{RunResults: evaluationsErrors})
+	c.Logger.Info("Evaluate Alert API - Done", "results", results)
+	return response.JSON(http.StatusOK, apimodels.EvalRunsResponse{RunResults: results})
 }
 
 func (srv *LogzioAlertingService) addQuerySourceHeader(c *contextmodel.ReqContext) http.Header {

--- a/pkg/services/ngalert/api/alerting_logzio.go
+++ b/pkg/services/ngalert/api/alerting_logzio.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/schedule"
 	"github.com/grafana/grafana/pkg/setting"
 	"net/http"
+	"context"
 )
 
 type LogzioAlertingService struct {
@@ -53,13 +54,10 @@ func (srv *LogzioAlertingService) RouteEvaluateAlert(c *contextmodel.ReqContext,
 			FolderTitle: evalRequest.FolderTitle,
 			LogzHeaders: srv.addQuerySourceHeader(c),
 		}
-		err := srv.Schedule.RunRuleEvaluation(c.Req.Context(), evalReq)
 
-		if err != nil {
-			evaluationsErrors = append(evaluationsErrors, apimodels.AlertEvalRunResult{UID: evalRequest.AlertRule.UID, EvalTime: evalRequest.EvalTime, RunResult: err.Error()})
-		} else {
-			evaluationsErrors = append(evaluationsErrors, apimodels.AlertEvalRunResult{UID: evalRequest.AlertRule.UID, EvalTime: evalRequest.EvalTime, RunResult: "success"})
-		}
+		go func(ctx context.Context, request ngmodels.ExternalAlertEvaluationRequest) {
+			srv.Schedule.RunRuleEvaluation(ctx, request)
+		}(c.Req.Context(), evalReq)
 	}
 
 	c.Logger.Info("Evaluate Alert API - Done", "evalErrors", evaluationsErrors)


### PR DESCRIPTION
Grafana evaluations extracted to goroutines to enable skipping of the slow alerts and reduce API response time