### PR TITLE
DEV-46879 - Create endpoints to return summary of datasources

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -392,6 +392,10 @@ func (hs *HTTPServer) registerRoutes() {
 			datasourceRoute.Get("/uid/:uid", authorize(ac.EvalPermission(datasources.ActionRead, uidScope)), routing.Wrap(hs.GetDataSourceByUID))
 			datasourceRoute.Get("/name/:name", authorize(ac.EvalPermission(datasources.ActionRead, nameScope)), routing.Wrap(hs.GetDataSourceByName))
 			datasourceRoute.Get("/id/:name", authorize(ac.EvalPermission(datasources.ActionIDRead, nameScope)), routing.Wrap(hs.GetDataSourceIdByName))
+			// LOGZ.IO GRAFANA CHANGE :: DEV-46879 - Create endpoints to return summary of datasources
+			datasourceRoute.Get("/summary", authorize(ac.EvalPermission(datasources.ActionRead)), routing.Wrap(hs.GetDataSourcesSummary))
+			datasourceRoute.Get("/name/:name/summary", authorize(ac.EvalPermission(datasources.ActionRead, nameScope)), routing.Wrap(hs.GetDataSourceSummaryByName))
+			// LOGZ.IO GRAFANA CHANGE :: End
 		})
 
 		pluginIDScope := pluginaccesscontrol.ScopeProvider.GetResourceScope(ac.Parameter(":pluginId"))

--- a/pkg/api/dtos/datasource.go
+++ b/pkg/api/dtos/datasource.go
@@ -61,3 +61,28 @@ func (slice DataSourceList) Less(i, j int) bool {
 func (slice DataSourceList) Swap(i, j int) {
 	slice[i], slice[j] = slice[j], slice[i]
 }
+
+// LOGZ.IO GRAFANA CHANGE :: DEV-46879 - Create endpoints to return summary of datasources
+type DataSourceSummaryListItemDTO struct {
+	Id       int64  `json:"id"`
+	UID      string `json:"uid"`
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Database string `json:"database"`
+}
+
+type DataSourceSummaryList []DataSourceSummaryListItemDTO
+
+func (slice DataSourceSummaryList) Len() int {
+	return len(slice)
+}
+
+func (slice DataSourceSummaryList) Less(i, j int) bool {
+	return strings.ToLower(slice[i].Name) < strings.ToLower(slice[j].Name)
+}
+
+func (slice DataSourceSummaryList) Swap(i, j int) {
+	slice[i], slice[j] = slice[j], slice[i]
+}
+
+// LOGZ.IO GRAFANA CHANGE :: End


### PR DESCRIPTION
In previous version of grafana (8.5) we added endpoints for datasources that can be used via the public API
These are so users can get information of the datasources that is available to them, without giving access to the existing datasources APIs that return information that we consider internal and not relevant for regular users and only for the system admin.

2 endpoints added:
GET /api/datasources/summary getDataSourcesSummary
GET /api/datasources/name/:name/summary getDataSourcesSummaryByName