### PR TITLE
DEV-47984 - Fix missing headers from queries with expression

### DIFF
--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -350,11 +350,16 @@ func (dn *DSNode) Execute(ctx context.Context, now time.Time, _ mathexp.Vars, s 
 	}()
 
 	// LOGZ.IO GRAFANA CHANGE :: DEV-43889 - Add headers for logzio datasources support
-	logzHeaders := http.Header{}
-	for k, v := range req.Headers {
-		logzHeaders[k] = []string{v}
+	ctxWithLogzio := ctx
+	_, ok := models.LogzIoHeadersFromContext(ctx)
+	if !ok {
+		logger.Debug("Adding logz context because it is missing")
+		logzHeaders := http.Header{}
+		for k, v := range req.Headers {
+			logzHeaders[k] = []string{v}
+		}
+		ctxWithLogzio = models.WithLogzHeaders(ctx, logzHeaders)
 	}
-	ctxWithLogzio := models.WithLogzHeaders(ctx, logzHeaders)
 
 	resp, err := s.dataService.QueryData(ctxWithLogzio, req)
 	// LOGZ.IO GRAFANA CHANGE :: End


### PR DESCRIPTION
**The bug:**
When using expression on Logs datasource in dashboard queries, it would return Data source error

**Root cause:**
* The query request using expressions would not have the logz headers, so requests to elasticsearch datasources would fail with 400 becaues it is missing.

* Addition of context in execute node (pkg/expr/nodes.go:309) was resetting the values with no headers when they arrived from the context via the /api/ds/query endpoint used from dashboards.

**Fix:**
Changed the behavior to add from request headers only if it is missing so it will not override with empty map.