### PR TITLE
DEV-48075 - Fix missing warning from NoData in prometheus converter

### DIFF
--- a/pkg/tsdb/prometheus/converter/prom.go
+++ b/pkg/tsdb/prometheus/converter/prom.go
@@ -91,6 +91,10 @@ l1Fields:
 	}
 
 	if len(warnings) > 0 {
+		if len(rsp.Frames) == 0 {
+			rsp.Frames = append(rsp.Frames, data.NewFrame("Warnings"))
+		}
+
 		for _, frame := range rsp.Frames {
 			if frame.Meta == nil {
 				frame.Meta = &data.FrameMeta{}

--- a/pkg/tsdb/prometheus/converter/prom.go
+++ b/pkg/tsdb/prometheus/converter/prom.go
@@ -91,9 +91,11 @@ l1Fields:
 	}
 
 	if len(warnings) > 0 {
+		// LOGZ.IO GRAFANA CHANGE :: DEV-48075 - Fix missing warning from NoData in prometheus converter
 		if len(rsp.Frames) == 0 {
 			rsp.Frames = append(rsp.Frames, data.NewFrame("Warnings"))
 		}
+		// LOGZ.IO GRAFANA CHANGE :: End
 
 		for _, frame := range rsp.Frames {
 			if frame.Meta == nil {

--- a/pkg/tsdb/prometheus/converter/prom_test.go
+++ b/pkg/tsdb/prometheus/converter/prom_test.go
@@ -28,6 +28,7 @@ var files = []string{
 	"prom-scalar",
 	"prom-series",
 	"prom-warnings",
+	"prom-warnings-no-data",
 	"prom-error",
 	"prom-exemplars-a",
 	"prom-exemplars-b",
@@ -57,6 +58,19 @@ func runScenario(name string, opts Options) func(t *testing.T) {
 			require.Error(t, rsp.Error)
 			return
 		}
+
+		if strings.Contains(name, "warnings") {
+			hasWarning := false
+			for _, frame := range rsp.Frames {
+				if len(frame.Meta.Notices) > 0 {
+					hasWarning = true
+					break
+				}
+			}
+
+			require.True(t, hasWarning)
+		}
+
 		require.NoError(t, rsp.Error)
 
 		fname := name + "-frame"

--- a/pkg/tsdb/prometheus/converter/prom_test.go
+++ b/pkg/tsdb/prometheus/converter/prom_test.go
@@ -28,7 +28,7 @@ var files = []string{
 	"prom-scalar",
 	"prom-series",
 	"prom-warnings",
-	"prom-warnings-no-data",
+	"prom-warnings-no-data", // LOGZ.IO GRAFANA CHANGE :: DEV-48075 - Fix missing warning from NoData in prometheus converter
 	"prom-error",
 	"prom-exemplars-a",
 	"prom-exemplars-b",
@@ -59,6 +59,7 @@ func runScenario(name string, opts Options) func(t *testing.T) {
 			return
 		}
 
+		// LOGZ.IO GRAFANA CHANGE :: DEV-48075 - Fix missing warning from NoData in prometheus converter
 		if strings.Contains(name, "warnings") {
 			hasWarning := false
 			for _, frame := range rsp.Frames {
@@ -70,6 +71,7 @@ func runScenario(name string, opts Options) func(t *testing.T) {
 
 			require.True(t, hasWarning)
 		}
+		// LOGZ.IO GRAFANA CHANGE :: End
 
 		require.NoError(t, rsp.Error)
 

--- a/pkg/tsdb/prometheus/converter/testdata/prom-warnings-no-data-frame.jsonc
+++ b/pkg/tsdb/prometheus/converter/testdata/prom-warnings-no-data-frame.jsonc
@@ -1,0 +1,55 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//
+//  Frame[0] {
+//      "typeVersion": [
+//          0,
+//          0
+//      ],
+//      "notices": [
+//          {
+//              "severity": "warning",
+//              "text": "warning 1"
+//          },
+//          {
+//              "severity": "warning",
+//              "text": "warning 2"
+//          }
+//      ]
+//  }
+//  Name: Warnings
+//  Dimensions: 0 Fields by 0 Rows
+//  +
+//  +
+//
+//
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "Warnings",
+        "meta": {
+          "typeVersion": [
+            0,
+            0
+          ],
+          "notices": [
+            {
+              "severity": "warning",
+              "text": "warning 1"
+            },
+            {
+              "severity": "warning",
+              "text": "warning 2"
+            }
+          ]
+        },
+        "fields": []
+      },
+      "data": {
+        "values": []
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/prometheus/converter/testdata/prom-warnings-no-data.json
+++ b/pkg/tsdb/prometheus/converter/testdata/prom-warnings-no-data.json
@@ -1,0 +1,8 @@
+{
+  "status" : "success",
+  "data" : {
+    "resultType" : "vector",
+    "result" : []
+  },
+  "warnings" : ["warning 1", "warning 2"]
+}


### PR DESCRIPTION
This fix is based on the following:
https://github.com/grafana/grafana/pull/93936

It was fixed on a later version on new prometheus client, but relevant for the current one as well.

**The Issue**
When running queries that return no data , but has warnings attached to it, we will not see the warning.
Even though the resulsts from datasource do contain a warning:
![image](https://github.com/user-attachments/assets/47bb38c5-07c1-45f7-bc44-3404c504abed)

We expect to see:
![image](https://github.com/user-attachments/assets/f45ad2d5-9b55-439d-9365-ea187002dac9)
But instead not seeing any warning, only No Data.
This is confusing since you don't know if there's an actual problem with missing data or the query is too big.

**Root Cause**
In the prometheus converter we are adding warnings to response on the response frames.
But in case of no-data there are no frames in response, causing nothing to be added.
<img width="397" alt="Screenshot 2025-02-04 at 12 30 50" src="https://github.com/user-attachments/assets/d35d0e1d-8ddd-49a4-9587-6971ab8a682f" />

**Suggested Fix**
Fix is pretty simple - just add the case where there are no frames in response and create a new frame for warnings and add it there.
<img width="564" alt="Screenshot 2025-02-04 at 12 33 45" src="https://github.com/user-attachments/assets/c2d371cf-bd40-44d2-9710-18e38f88ea77" />
