### PR TITLE
DEV-48550 - Add state transition to alert annotations

### DIFF
--- a/pkg/services/ngalert/state/compat.go
+++ b/pkg/services/ngalert/state/compat.go
@@ -27,6 +27,8 @@ const (
 	ErrorAlertName  = "DatasourceError"
 
 	Rulename = "rulename"
+
+	LogzioStateTransitionAnnotation = "__logzioStateTransition__" // LOGZ.IO GRAFANA CHANGE :: DEV-48550 - Add state transition to annotations
 )
 
 // StateToPostableAlert converts a state to a model that is accepted by Alertmanager. Annotations and Labels are copied from the state.
@@ -158,6 +160,8 @@ func FromStateTransitionToPostableAlerts(firingStates []StateTransition, stateMa
 			if logzAccountId != "" {
 				alert.Annotations[ngModels.LogzioAccountIdAnnotation] = logzAccountId
 			}
+
+			alert.Annotations[LogzioStateTransitionAnnotation] = fmt.Sprintf("{\"state\":\"%v\",\"previousState\":\"%v\"}", alertState.State.State, alertState.PreviousState) // LOGZ.IO GRAFANA CHANGE :: DEV-48550 - Add state transition to annotations
 		}
 		// LOGZ.IO GRAFANA CHANGE :: End
 		alerts.PostableAlerts = append(alerts.PostableAlerts, *alert)

--- a/pkg/services/ngalert/state/compat.go
+++ b/pkg/services/ngalert/state/compat.go
@@ -160,9 +160,8 @@ func FromStateTransitionToPostableAlerts(firingStates []StateTransition, stateMa
 			if logzAccountId != "" {
 				alert.Annotations[ngModels.LogzioAccountIdAnnotation] = logzAccountId
 			}
-
-			alert.Annotations[LogzioStateTransitionAnnotation] = fmt.Sprintf("{\"state\":\"%v\",\"previousState\":\"%v\"}", alertState.State.State, alertState.PreviousState) // LOGZ.IO GRAFANA CHANGE :: DEV-48550 - Add state transition to annotations
 		}
+		alert.Annotations[LogzioStateTransitionAnnotation] = fmt.Sprintf("{\"state\":\"%v\",\"previousState\":\"%v\"}", alertState.State.State, alertState.PreviousState) // LOGZ.IO GRAFANA CHANGE :: DEV-48550 - Add state transition to annotations
 		// LOGZ.IO GRAFANA CHANGE :: End
 		alerts.PostableAlerts = append(alerts.PostableAlerts, *alert)
 		if alertState.StateReason == ngModels.StateReasonMissingSeries { // do not put stale state back to state manager


### PR DESCRIPTION
In order to support external feature that depends on the current and previous state of the alert, 
we want to add the state transition data for each postable alert inside their annotation so it can be used for further calculations.