### PR TITLE
AI-40 - Add observability to alertmanagers load time

### DIFF
--- a/pkg/services/ngalert/metrics/multi_org_alertmanager.go
+++ b/pkg/services/ngalert/metrics/multi_org_alertmanager.go
@@ -17,7 +17,7 @@ type MultiOrgAlertmanager struct {
 
 	ActiveConfigurations         prometheus.Gauge
 	DiscoveredConfigurations     prometheus.Gauge
-	SyncAlertmanagersTimeSeconds prometheus.Gauge
+	SyncAlertmanagersTimeSeconds prometheus.Gauge // LOGZ.IO GRAFANA CHANGE :: AI-40 - Add observability to alertmanagers load time
 
 	aggregatedMetrics *AlertmanagerAggregatedMetrics
 }
@@ -39,12 +39,14 @@ func NewMultiOrgAlertmanagerMetrics(r prometheus.Registerer) *MultiOrgAlertmanag
 			Name:      "active_configurations",
 			Help:      "The number of active Alertmanager configurations.",
 		}),
+		// LOGZ.IO GRAFANA CHANGE :: AI-40 - Add observability to alertmanagers load time
 		SyncAlertmanagersTimeSeconds: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Subsystem: Subsystem,
 			Name:      "sync_alertmanagers_time_seconds",
-			Help:      "The time it took to sync all Alertmanagers.",
+			Help:      "The time it took to load and sync all Alertmanagers.",
 		}),
+		// LOGZ.IO GRAFANA CHANGE :: End
 		aggregatedMetrics: NewAlertmanagerAggregatedMetrics(registries),
 	}
 

--- a/pkg/services/ngalert/metrics/multi_org_alertmanager.go
+++ b/pkg/services/ngalert/metrics/multi_org_alertmanager.go
@@ -15,8 +15,9 @@ type MultiOrgAlertmanager struct {
 	Registerer prometheus.Registerer
 	registries *metrics.TenantRegistries
 
-	ActiveConfigurations     prometheus.Gauge
-	DiscoveredConfigurations prometheus.Gauge
+	ActiveConfigurations         prometheus.Gauge
+	DiscoveredConfigurations     prometheus.Gauge
+	SyncAlertmanagersTimeSeconds prometheus.Gauge
 
 	aggregatedMetrics *AlertmanagerAggregatedMetrics
 }
@@ -37,6 +38,12 @@ func NewMultiOrgAlertmanagerMetrics(r prometheus.Registerer) *MultiOrgAlertmanag
 			Subsystem: Subsystem,
 			Name:      "active_configurations",
 			Help:      "The number of active Alertmanager configurations.",
+		}),
+		SyncAlertmanagersTimeSeconds: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      "sync_alertmanagers_time_seconds",
+			Help:      "The time it took to sync all Alertmanagers.",
 		}),
 		aggregatedMetrics: NewAlertmanagerAggregatedMetrics(registries),
 	}

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -164,6 +164,7 @@ type AlertNG struct {
 
 func (ng *AlertNG) init() error {
 	// AlertNG should be initialized before the cancellation deadline of initCtx
+	ng.Log.Debug("Initializing context with timeout from config", "init_timeout_duration", ng.Cfg.UnifiedAlerting.InitializationTimeout)
 	initCtx, cancelFunc := context.WithTimeout(context.Background(), ng.Cfg.UnifiedAlerting.InitializationTimeout) // LOGZ.IO GRAFANA CHANGE :: DEV-48976 - Make context deadline on AlertNG service startup configurable - cherrypick from: 1fdc48fabafe8b8480a58fb4a169d01ebb535fb2
 	defer cancelFunc()
 

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -164,8 +164,8 @@ type AlertNG struct {
 
 func (ng *AlertNG) init() error {
 	// AlertNG should be initialized before the cancellation deadline of initCtx
-	ng.Log.Debug("Initializing context with timeout from config", "init_timeout_duration", ng.Cfg.UnifiedAlerting.InitializationTimeout)
-	initCtx, cancelFunc := context.WithTimeout(context.Background(), ng.Cfg.UnifiedAlerting.InitializationTimeout) // LOGZ.IO GRAFANA CHANGE :: DEV-48976 - Make context deadline on AlertNG service startup configurable - cherrypick from: 1fdc48fabafe8b8480a58fb4a169d01ebb535fb2
+	ng.Log.Debug("Initializing context with timeout from config", "init_timeout_duration", ng.Cfg.UnifiedAlerting.InitializationTimeout) // LOGZ.IO GRAFANA CHANGE :: AI-40 - Add observability to alertmanagers load time
+	initCtx, cancelFunc := context.WithTimeout(context.Background(), ng.Cfg.UnifiedAlerting.InitializationTimeout)                       // LOGZ.IO GRAFANA CHANGE :: DEV-48976 - Make context deadline on AlertNG service startup configurable - cherrypick from: 1fdc48fabafe8b8480a58fb4a169d01ebb535fb2
 	defer cancelFunc()
 
 	ng.store.Logger = ng.Log

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -226,6 +226,7 @@ func (moa *MultiOrgAlertmanager) Run(ctx context.Context) error {
 }
 
 func (moa *MultiOrgAlertmanager) LoadAndSyncAlertmanagersForOrgs(ctx context.Context) error {
+	startTime := time.Now()
 	moa.logger.Debug("Synchronizing Alertmanagers for orgs")
 	// First, load all the organizations from the database.
 	orgIDs, err := moa.orgStore.GetOrgs(ctx)
@@ -237,7 +238,7 @@ func (moa *MultiOrgAlertmanager) LoadAndSyncAlertmanagersForOrgs(ctx context.Con
 	moa.metrics.DiscoveredConfigurations.Set(float64(len(orgIDs)))
 	moa.SyncAlertmanagersForOrgs(ctx, orgIDs)
 
-	moa.logger.Debug("Done synchronizing Alertmanagers for orgs")
+	moa.logger.Debug("Done synchronizing Alertmanagers for orgs", "duration_seconds", time.Since(startTime).Seconds())
 
 	return nil
 }

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -226,7 +226,7 @@ func (moa *MultiOrgAlertmanager) Run(ctx context.Context) error {
 }
 
 func (moa *MultiOrgAlertmanager) LoadAndSyncAlertmanagersForOrgs(ctx context.Context) error {
-	startTime := time.Now()
+	startTime := time.Now() // LOGZ.IO GRAFANA CHANGE :: AI-40 - Add observability to alertmanagers load time
 	moa.logger.Debug("Synchronizing Alertmanagers for orgs")
 	// First, load all the organizations from the database.
 	orgIDs, err := moa.orgStore.GetOrgs(ctx)
@@ -238,9 +238,11 @@ func (moa *MultiOrgAlertmanager) LoadAndSyncAlertmanagersForOrgs(ctx context.Con
 	moa.metrics.DiscoveredConfigurations.Set(float64(len(orgIDs)))
 	moa.SyncAlertmanagersForOrgs(ctx, orgIDs)
 
+	// LOGZ.IO GRAFANA CHANGE :: AI-40 - Add observability to alertmanagers load time
 	loadingTime := time.Since(startTime).Seconds()
 	moa.metrics.SyncAlertmanagersTimeSeconds.Set(loadingTime)
 	moa.logger.Debug("Done synchronizing Alertmanagers for orgs", "duration_seconds", loadingTime)
+	// LOGZ.IO GRAFANA CHANGE :: End
 
 	return nil
 }

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -238,7 +238,9 @@ func (moa *MultiOrgAlertmanager) LoadAndSyncAlertmanagersForOrgs(ctx context.Con
 	moa.metrics.DiscoveredConfigurations.Set(float64(len(orgIDs)))
 	moa.SyncAlertmanagersForOrgs(ctx, orgIDs)
 
-	moa.logger.Debug("Done synchronizing Alertmanagers for orgs", "duration_seconds", time.Since(startTime).Seconds())
+	loadingTime := time.Since(startTime).Seconds()
+	moa.metrics.SyncAlertmanagersTimeSeconds.Set(loadingTime)
+	moa.logger.Debug("Done synchronizing Alertmanagers for orgs", "duration_seconds", loadingTime)
 
 	return nil
 }


### PR DESCRIPTION
Add observability for the alertmanagers load and sync time so we can properly monitor if we are close to the config limit.
* added timer for the loading time on LoadAndSyncAlertmanagersForOrgs
* added new metric with load time
* added load time on existing log
* added log information for the context init timeout that setting value
* reverted back to use config instead of hardcoded limit