### PR TITLE
DC-339: Trigger Grafana build in release-engineering via repository_dispatch

### DIFF
--- a/.github/workflows/dispatch-grafana-build.yml
+++ b/.github/workflows/dispatch-grafana-build.yml
@@ -1,0 +1,41 @@
+name: Dispatch Grafana Build
+
+# Migrated trigger for the Jenkins `build-and-publish-grafana` job.
+# This repo (data-viz-next) is public, so the actual build runs in the private
+# logzio/release-engineering repo. On every push to the main Logz.io branch we send a
+# repository_dispatch that fires release-engineering/.github/workflows/build-grafana.yaml.
+#
+# Requires the org GitHub App (GH_APP_ID / GH_APP_PRIVATE_KEY secrets) to be installed on
+# both data-viz-next and release-engineering with actions:write on release-engineering.
+
+on:
+  push:
+    branches: [v10.4.x-logzio]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: Trigger release-engineering build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: release-engineering
+
+      - name: Send repository_dispatch to release-engineering
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SHA: ${{ github.sha }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          jq -nc --arg sha "$SHA" --arg branch "$BRANCH" \
+            '{event_type: "grafana-build", client_payload: {sha: $sha, branch: $branch}}' \
+          | gh api -X POST repos/logzio/release-engineering/dispatches --input -
+          echo "Dispatched grafana-build for $BRANCH @ $SHA"


### PR DESCRIPTION
## What

Adds `.github/workflows/dispatch-grafana-build.yml`. On every push to `v10.4.x-logzio`, it sends a `repository_dispatch` (`grafana-build`) to **logzio/release-engineering**, which runs the actual Grafana image build and publish.

This is the trigger half of migrating the Jenkins `build-and-publish-grafana` job off Jenkins. The build logic itself lives in release-engineering (private) rather than here, because this repo is public — we don't want internal infra (AWS account, ECR/S3 bucket names, self-hosted runner labels) or self-hosted runners exposed publicly. See logzio/release-engineering#276.

## Requires

- Org GitHub App (`GH_APP_ID` / `GH_APP_PRIVATE_KEY` secrets) installed on this repo and on release-engineering, with `actions:write` on release-engineering so the dispatch is accepted.

Refs logzio/devops-team#339

🤖 Generated with [Claude Code](https://claude.com/claude-code)