### PR TITLE
APPZ-2728 - Allow editors to use alert provisioning API with decrypted secrets

### DIFF
--- a/pkg/services/ngalert/accesscontrol.go
+++ b/pkg/services/ngalert/accesscontrol.go
@@ -199,7 +199,7 @@ var (
 				},
 			},
 		},
-		Grants: []string{string(org.RoleAdmin)},
+		Grants: []string{string(org.RoleEditor), string(org.RoleAdmin)}, // LOGZ.IO GRAFANA CHANGE :: APPZ-2728 - Allow editors to use alert provisioning API with decrypted secrets
 	}
 )
 


### PR DESCRIPTION

**What is this feature?**

add EditorRole to alertingProvisioningReaderWithSecretsRole

**Why do we need this feature?**

we want to let users use export endpoint for contact-points which has the decrypt param.
currently the decrypt works only for Admins and we want users with Editor role to be able to fetch decrypted data of alert provisioning as well.
