### PR TITLE
APPZ-1782 - Parallelize per-org Alertmanager sync to reduce startup time

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1153,7 +1153,6 @@ admin_config_poll_interval = 60s
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 alertmanager_config_poll_interval = 60s
 
-# LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync
 # Number of organizations whose Alertmanagers are initialized concurrently during load and sync (startup and periodic resync).
 # Higher values reduce startup time when there are many organizations, at the cost of more concurrent work. Minimum 1.
 alertmanager_sync_concurrency = 10

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1153,6 +1153,11 @@ admin_config_poll_interval = 60s
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 alertmanager_config_poll_interval = 60s
 
+# LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync
+# Number of organizations whose Alertmanagers are initialized concurrently during load and sync (startup and periodic resync).
+# Higher values reduce startup time when there are many organizations, at the cost of more concurrent work. Minimum 1.
+alertmanager_sync_concurrency = 10
+
 # The redis server address that should be connected to.
 ha_redis_address =
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1070,6 +1070,10 @@
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 ;alertmanager_config_poll_interval = 60s
 
+# LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync
+# Number of organizations whose Alertmanagers are initialized concurrently during load and sync (startup and periodic resync). Minimum 1.
+;alertmanager_sync_concurrency = 10
+
 # The redis server address that should be connected to.
 ;ha_redis_address =
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1070,7 +1070,6 @@
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 ;alertmanager_config_poll_interval = 60s
 
-# LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync
 # Number of organizations whose Alertmanagers are initialized concurrently during load and sync (startup and periodic resync). Minimum 1.
 ;alertmanager_sync_concurrency = 10
 

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -11,7 +11,7 @@ import (
 
 	alertingCluster "github.com/grafana/alerting/cluster"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/sync/errgroup" // LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync
+	"golang.org/x/sync/errgroup"
 
 	alertingNotify "github.com/grafana/alerting/notify"
 
@@ -242,8 +242,6 @@ func (moa *MultiOrgAlertmanager) LoadAndSyncAlertmanagersForOrgs(ctx context.Con
 	// LOGZ.IO GRAFANA CHANGE :: AI-40 - Add observability to alertmanagers load time
 	loadingTime := time.Since(startTime).Seconds()
 	moa.metrics.SyncAlertmanagersTimeSeconds.Set(loadingTime)
-	// LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Log org count and duration at Info level so the per-restart
-	// sync cost is visible without enabling debug logging for this logger.
 	moa.logger.Info("Done synchronizing Alertmanagers for orgs", "org_count", len(orgIDs), "duration_seconds", loadingTime)
 	// LOGZ.IO GRAFANA CHANGE :: End
 
@@ -273,10 +271,8 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 		moa.logger.Error("Failed to load Alertmanager configurations", "error", err)
 		return
 	}
-	// LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync to reduce O(n) startup time.
-	// Snapshot the running Alertmanagers under a read lock. This method is the only writer of
-	// moa.alertmanagers and runs serially (once during init, then the single-goroutine poll loop), so the
-	// snapshot is consistent and lets the heavy per-org work run concurrently without touching the shared map.
+	// Snapshot the running Alertmanagers under a read lock so the per-org work below can run concurrently
+	// without holding the lock. This method is the only writer of moa.alertmanagers and runs serially.
 	moa.alertmanagersMtx.RLock()
 	existing := make(map[int64]Alertmanager, len(moa.alertmanagers))
 	for orgID, am := range moa.alertmanagers {
@@ -295,13 +291,11 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 		syncOrgs = append(syncOrgs, orgID)
 	}
 
-	// Run the expensive per-org work (factory + ApplyConfig) concurrently, bounded by the configured limit.
-	// Each goroutine writes its result into its own index-aligned slot, so no synchronization is needed during
-	// this phase. Failures are logged and leave a nil slot, preserving the previous "log and skip" behavior.
+	// Each goroutine writes its result into its own index-aligned slot, so no locking is needed here.
+	// Failures are logged and leave a nil slot, preserving the previous "log and skip" behavior.
 	synced := make([]Alertmanager, len(syncOrgs))
 	var g errgroup.Group
-	// Guard the limit here as well as in settings parsing: SetLimit(0) would block every goroutine
-	// forever, and the MOA can be constructed with a Cfg that wasn't built through ReadUnifiedAlertingSettings.
+	// SetLimit(0) would block every goroutine forever; floor it (a Cfg may be built without ReadUnifiedAlertingSettings).
 	concurrency := moa.settings.UnifiedAlerting.SyncConcurrency
 	if concurrency < 1 {
 		concurrency = 1
@@ -310,8 +304,8 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 	for i, orgID := range syncOrgs {
 		i, orgID := i, orgID
 		g.Go(func() error {
-			alertmanager, found := existing[orgID]
-			if !found {
+			alertmanager, alertmanagerFound := existing[orgID]
+			if !alertmanagerFound {
 				// These metrics are not exported by Grafana and are mostly a placeholder.
 				// To export them, we need to translate the metrics from each individual registry and,
 				// then aggregate them on the main registry.
@@ -322,14 +316,12 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 				}
 				alertmanager = am
 			}
-			// Register the Alertmanager as soon as it exists (created or reused), before applying config.
-			// This matches the original behavior where a failed config application leaves a non-ready
-			// Alertmanager in the map rather than dropping it.
+			// Register the AM before applying config: a failed apply must still leave it (not-ready) in the map.
 			synced[i] = alertmanager
 
 			dbConfig, cfgFound := dbConfigs[orgID]
 			if !cfgFound {
-				if found {
+				if alertmanagerFound {
 					// This means that the configuration is gone but the organization, as well as the Alertmanager, exists.
 					moa.logger.Warn("Alertmanager exists for org but the configuration is gone. Applying the default configuration", "org", orgID)
 				}
@@ -347,8 +339,7 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 	}
 	_ = g.Wait() // goroutines never return an error; failures are logged above and the org is skipped.
 
-	// Merge the synced Alertmanagers and prune removed orgs under the write lock. This phase is fast and does
-	// no I/O, so briefly holding the lock here does not reintroduce the O(n) cost.
+	// Merge results and prune removed orgs under the write lock. This phase is fast and does no I/O.
 	moa.alertmanagersMtx.Lock()
 	for i, orgID := range syncOrgs {
 		if synced[i] != nil {
@@ -366,7 +357,6 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 	}
 	moa.metrics.ActiveConfigurations.Set(float64(len(moa.alertmanagers)))
 	moa.alertmanagersMtx.Unlock()
-	// LOGZ.IO GRAFANA CHANGE :: End
 
 	// Now, we can stop the Alertmanagers without having to hold a lock.
 	for orgID, am := range amsToStop {

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -11,6 +11,7 @@ import (
 
 	alertingCluster "github.com/grafana/alerting/cluster"
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sync/errgroup" // LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync
 
 	alertingNotify "github.com/grafana/alerting/notify"
 
@@ -241,7 +242,9 @@ func (moa *MultiOrgAlertmanager) LoadAndSyncAlertmanagersForOrgs(ctx context.Con
 	// LOGZ.IO GRAFANA CHANGE :: AI-40 - Add observability to alertmanagers load time
 	loadingTime := time.Since(startTime).Seconds()
 	moa.metrics.SyncAlertmanagersTimeSeconds.Set(loadingTime)
-	moa.logger.Debug("Done synchronizing Alertmanagers for orgs", "duration_seconds", loadingTime)
+	// LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Log org count and duration at Info level so the per-restart
+	// sync cost is visible without enabling debug logging for this logger.
+	moa.logger.Info("Done synchronizing Alertmanagers for orgs", "org_count", len(orgIDs), "duration_seconds", loadingTime)
 	// LOGZ.IO GRAFANA CHANGE :: End
 
 	return nil
@@ -270,50 +273,87 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 		moa.logger.Error("Failed to load Alertmanager configurations", "error", err)
 		return
 	}
-	moa.alertmanagersMtx.Lock()
+	// LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync to reduce O(n) startup time.
+	// Snapshot the running Alertmanagers under a read lock. This method is the only writer of
+	// moa.alertmanagers and runs serially (once during init, then the single-goroutine poll loop), so the
+	// snapshot is consistent and lets the heavy per-org work run concurrently without touching the shared map.
+	moa.alertmanagersMtx.RLock()
+	existing := make(map[int64]Alertmanager, len(moa.alertmanagers))
+	for orgID, am := range moa.alertmanagers {
+		existing[orgID] = am
+	}
+	moa.alertmanagersMtx.RUnlock()
+
+	// Determine which orgs to sync, skipping disabled ones.
+	syncOrgs := make([]int64, 0, len(orgIDs))
 	for _, orgID := range orgIDs {
 		if _, isDisabledOrg := moa.settings.UnifiedAlerting.DisabledOrgs[orgID]; isDisabledOrg {
 			moa.logger.Debug("Skipping syncing Alertmanager for disabled org", "org", orgID)
 			continue
 		}
 		orgsFound[orgID] = struct{}{}
+		syncOrgs = append(syncOrgs, orgID)
+	}
 
-		alertmanager, found := moa.alertmanagers[orgID]
-
-		if !found {
-			// These metrics are not exported by Grafana and are mostly a placeholder.
-			// To export them, we need to translate the metrics from each individual registry and,
-			// then aggregate them on the main registry.
-			am, err := moa.factory(ctx, orgID)
-			if err != nil {
-				moa.logger.Error("Unable to create Alertmanager for org", "org", orgID, "error", err)
-				continue
+	// Run the expensive per-org work (factory + ApplyConfig) concurrently, bounded by the configured limit.
+	// Each goroutine writes its result into its own index-aligned slot, so no synchronization is needed during
+	// this phase. Failures are logged and leave a nil slot, preserving the previous "log and skip" behavior.
+	synced := make([]Alertmanager, len(syncOrgs))
+	var g errgroup.Group
+	// Guard the limit here as well as in settings parsing: SetLimit(0) would block every goroutine
+	// forever, and the MOA can be constructed with a Cfg that wasn't built through ReadUnifiedAlertingSettings.
+	concurrency := moa.settings.UnifiedAlerting.SyncConcurrency
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	g.SetLimit(concurrency)
+	for i, orgID := range syncOrgs {
+		i, orgID := i, orgID
+		g.Go(func() error {
+			alertmanager, found := existing[orgID]
+			if !found {
+				// These metrics are not exported by Grafana and are mostly a placeholder.
+				// To export them, we need to translate the metrics from each individual registry and,
+				// then aggregate them on the main registry.
+				am, err := moa.factory(ctx, orgID)
+				if err != nil {
+					moa.logger.Error("Unable to create Alertmanager for org", "org", orgID, "error", err)
+					return nil // synced[i] stays nil: a failed factory means the org is not registered.
+				}
+				alertmanager = am
 			}
-			moa.alertmanagers[orgID] = am
-			alertmanager = am
-		}
+			// Register the Alertmanager as soon as it exists (created or reused), before applying config.
+			// This matches the original behavior where a failed config application leaves a non-ready
+			// Alertmanager in the map rather than dropping it.
+			synced[i] = alertmanager
 
-		dbConfig, cfgFound := dbConfigs[orgID]
-		if !cfgFound {
-			if found {
-				// This means that the configuration is gone but the organization, as well as the Alertmanager, exists.
-				moa.logger.Warn("Alertmanager exists for org but the configuration is gone. Applying the default configuration", "org", orgID)
+			dbConfig, cfgFound := dbConfigs[orgID]
+			if !cfgFound {
+				if found {
+					// This means that the configuration is gone but the organization, as well as the Alertmanager, exists.
+					moa.logger.Warn("Alertmanager exists for org but the configuration is gone. Applying the default configuration", "org", orgID)
+				}
+				if err := alertmanager.SaveAndApplyDefaultConfig(ctx); err != nil {
+					moa.logger.Error("Failed to apply the default Alertmanager configuration", "org", orgID)
+				}
+				return nil
 			}
-			err := alertmanager.SaveAndApplyDefaultConfig(ctx)
-			if err != nil {
-				moa.logger.Error("Failed to apply the default Alertmanager configuration", "org", orgID)
-				continue
-			}
-			moa.alertmanagers[orgID] = alertmanager
-			continue
-		}
 
-		err := alertmanager.ApplyConfig(ctx, dbConfig)
-		if err != nil {
-			moa.logger.Error("Failed to apply Alertmanager config for org", "org", orgID, "id", dbConfig.ID, "error", err)
-			continue
+			if err := alertmanager.ApplyConfig(ctx, dbConfig); err != nil {
+				moa.logger.Error("Failed to apply Alertmanager config for org", "org", orgID, "id", dbConfig.ID, "error", err)
+			}
+			return nil
+		})
+	}
+	_ = g.Wait() // goroutines never return an error; failures are logged above and the org is skipped.
+
+	// Merge the synced Alertmanagers and prune removed orgs under the write lock. This phase is fast and does
+	// no I/O, so briefly holding the lock here does not reintroduce the O(n) cost.
+	moa.alertmanagersMtx.Lock()
+	for i, orgID := range syncOrgs {
+		if synced[i] != nil {
+			moa.alertmanagers[orgID] = synced[i]
 		}
-		moa.alertmanagers[orgID] = alertmanager
 	}
 
 	amsToStop := map[int64]Alertmanager{}
@@ -326,6 +366,7 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 	}
 	moa.metrics.ActiveConfigurations.Set(float64(len(moa.alertmanagers)))
 	moa.alertmanagersMtx.Unlock()
+	// LOGZ.IO GRAFANA CHANGE :: End
 
 	// Now, we can stop the Alertmanagers without having to hold a lock.
 	for orgID, am := range amsToStop {

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
@@ -153,7 +153,6 @@ grafana_alerting_discovered_configurations 4
 	}
 }
 
-// LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync.
 // TestMultiOrgAlertmanager_SyncAlertmanagersConcurrency verifies that syncing many orgs with a higher
 // alertmanager_sync_concurrency is faster than syncing them serially (concurrency=1). Per-org init is
 // simulated with a fixed delay in the Alertmanager factory so the difference is dominated by how many

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
@@ -153,6 +153,77 @@ grafana_alerting_discovered_configurations 4
 	}
 }
 
+// LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync.
+// TestMultiOrgAlertmanager_SyncAlertmanagersConcurrency verifies that syncing many orgs with a higher
+// alertmanager_sync_concurrency is faster than syncing them serially (concurrency=1). Per-org init is
+// simulated with a fixed delay in the Alertmanager factory so the difference is dominated by how many
+// orgs are initialized at once rather than by I/O noise. The delays are sleeps, so they overlap even on
+// a single CPU, making the comparison robust under CI contention.
+func TestMultiOrgAlertmanager_SyncAlertmanagersConcurrency(t *testing.T) {
+	const (
+		numOrgs     = 20
+		perOrgDelay = 25 * time.Millisecond
+	)
+
+	// timeFirstSync builds a fresh MOA with the given concurrency, where each org's Alertmanager creation
+	// is delayed by perOrgDelay, and returns how long the initial load+sync of numOrgs orgs took.
+	timeFirstSync := func(t *testing.T, concurrency int) time.Duration {
+		t.Helper()
+
+		orgs := make([]int64, numOrgs)
+		for i := range orgs {
+			orgs[i] = int64(i + 1)
+		}
+
+		configStore := NewFakeConfigStore(t, map[int64]*models.AlertConfiguration{})
+		orgStore := &FakeOrgStore{orgs: orgs}
+		kvStore := ngfakes.NewFakeKVStore(t)
+		provStore := ngfakes.NewFakeProvisioningStore()
+		secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
+		decryptFn := secretsService.GetDecryptedValue
+		reg := prometheus.NewPedanticRegistry()
+		m := metrics.NewNGAlert(reg)
+		cfg := &setting.Cfg{
+			DataPath: t.TempDir(),
+			UnifiedAlerting: setting.UnifiedAlertingSettings{
+				AlertmanagerConfigPollInterval: 3 * time.Minute, // do not poll in tests.
+				DefaultConfiguration:           setting.GetAlertmanagerDefaultConfiguration(),
+				SyncConcurrency:                concurrency,
+			},
+		}
+
+		// Simulate expensive per-org initialization by delaying each Alertmanager's creation.
+		slowFactory := WithAlertmanagerOverride(func(orig OrgAlertmanagerFactory) OrgAlertmanagerFactory {
+			return func(ctx context.Context, orgID int64) (Alertmanager, error) {
+				time.Sleep(perOrgDelay)
+				return orig(ctx, orgID)
+			}
+		})
+
+		mam, err := NewMultiOrgAlertmanager(cfg, configStore, orgStore, kvStore, provStore, decryptFn, m.GetMultiOrgAlertmanagerMetrics(), nil, log.New("testlogger"), secretsService, &featuremgmt.FeatureManager{}, slowFactory)
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		start := time.Now()
+		require.NoError(t, mam.LoadAndSyncAlertmanagersForOrgs(ctx))
+		elapsed := time.Since(start)
+
+		require.Len(t, mam.alertmanagers, numOrgs)
+		return elapsed
+	}
+
+	serial := timeFirstSync(t, 1)
+	parallel := timeFirstSync(t, 10)
+
+	t.Logf("syncing %d orgs (per-org delay %s): serial (concurrency=1) took %s, parallel (concurrency=10) took %s (%.1fx faster)",
+		numOrgs, perOrgDelay, serial, parallel, float64(serial)/float64(parallel))
+
+	// With 10-way concurrency over 20 delayed initializations the parallel run should be roughly 10x
+	// faster. Assert a conservative >2x bound so the test stays robust under load while still failing if
+	// the work ever regresses to running serially.
+	require.Less(t, parallel, serial/2, "expected concurrent sync to be at least 2x faster than serial")
+}
+
 func TestMultiOrgAlertmanager_SyncAlertmanagersForOrgsWithFailures(t *testing.T) {
 	// Include a broken configuration for organization 2.
 	var orgWithBadConfig int64 = 2

--- a/pkg/services/ngalert/notifier/testing.go
+++ b/pkg/services/ngalert/notifier/testing.go
@@ -16,8 +16,7 @@ import (
 )
 
 type fakeConfigStore struct {
-	// mtx guards the maps below. The real store is safe for concurrent use, and SyncAlertmanagersForOrgs
-	// now syncs orgs concurrently, so the fake must be too (otherwise -race flags the fake, not prod code).
+	// mtx guards the maps below for concurrent access (the real store is safe for concurrent use).
 	mtx     sync.Mutex
 	configs map[int64]*models.AlertConfiguration
 

--- a/pkg/services/ngalert/notifier/testing.go
+++ b/pkg/services/ngalert/notifier/testing.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,6 +16,9 @@ import (
 )
 
 type fakeConfigStore struct {
+	// mtx guards the maps below. The real store is safe for concurrent use, and SyncAlertmanagersForOrgs
+	// now syncs orgs concurrently, so the fake must be too (otherwise -race flags the fake, not prod code).
+	mtx     sync.Mutex
 	configs map[int64]*models.AlertConfiguration
 
 	// historicConfigs stores configs by orgID.
@@ -25,6 +29,8 @@ type fakeConfigStore struct {
 }
 
 func (f *fakeConfigStore) ListNotificationSettings(ctx context.Context, q models.ListNotificationSettingsQuery) (map[models.AlertRuleKey][]models.NotificationSettings, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
 	settings, ok := f.notificationSettings[q.OrgID]
 	if !ok {
 		return nil, nil
@@ -87,6 +93,8 @@ func NewFakeConfigStore(t *testing.T, configs map[int64]*models.AlertConfigurati
 }
 
 func (f *fakeConfigStore) GetAllLatestAlertmanagerConfiguration(context.Context) ([]*models.AlertConfiguration, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
 	result := make([]*models.AlertConfiguration, 0, len(f.configs))
 	for _, configuration := range f.configs {
 		result = append(result, configuration)
@@ -95,6 +103,8 @@ func (f *fakeConfigStore) GetAllLatestAlertmanagerConfiguration(context.Context)
 }
 
 func (f *fakeConfigStore) GetLatestAlertmanagerConfiguration(_ context.Context, orgID int64) (*models.AlertConfiguration, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
 	config, ok := f.configs[orgID]
 	if !ok {
 		return nil, store.ErrNoAlertmanagerConfiguration
@@ -114,6 +124,9 @@ func (f *fakeConfigStore) SaveAlertmanagerConfigurationWithCallback(_ context.Co
 		ConfigurationVersion:      "v1",
 		Default:                   cmd.Default,
 	}
+
+	// Hold the lock only around the map mutations; the callback may re-enter the store.
+	f.mtx.Lock()
 	f.configs[cmd.OrgID] = &cfg
 
 	historicConfig := models.HistoricConfigFromAlertConfig(cfg)
@@ -121,6 +134,7 @@ func (f *fakeConfigStore) SaveAlertmanagerConfigurationWithCallback(_ context.Co
 		historicConfig.LastApplied = time.Now().UTC().Unix()
 		f.historicConfigs[cmd.OrgID] = append(f.historicConfigs[cmd.OrgID], &historicConfig)
 	}
+	f.mtx.Unlock()
 
 	if err := callback(); err != nil {
 		return err
@@ -130,6 +144,8 @@ func (f *fakeConfigStore) SaveAlertmanagerConfigurationWithCallback(_ context.Co
 }
 
 func (f *fakeConfigStore) UpdateAlertmanagerConfiguration(_ context.Context, cmd *models.SaveAlertmanagerConfigurationCmd) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
 	if config, exists := f.configs[cmd.OrgID]; exists && config.ConfigurationHash == cmd.FetchedConfigurationHash {
 		newConfig := models.AlertConfiguration{
 			AlertmanagerConfiguration: cmd.AlertmanagerConfiguration,
@@ -149,6 +165,8 @@ func (f *fakeConfigStore) UpdateAlertmanagerConfiguration(_ context.Context, cmd
 }
 
 func (f *fakeConfigStore) MarkConfigurationAsApplied(_ context.Context, cmd *models.MarkConfigurationAsAppliedCmd) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
 	orgConfigs, ok := f.historicConfigs[cmd.OrgID]
 	if !ok {
 		return nil
@@ -168,6 +186,8 @@ func (f *fakeConfigStore) MarkConfigurationAsApplied(_ context.Context, cmd *mod
 }
 
 func (f *fakeConfigStore) GetAppliedConfigurations(_ context.Context, orgID int64, limit int) ([]*models.HistoricAlertConfiguration, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
 	configsByOrg, ok := f.historicConfigs[orgID]
 	if !ok {
 		return []*models.HistoricAlertConfiguration{}, nil
@@ -191,6 +211,8 @@ func (f *fakeConfigStore) GetAppliedConfigurations(_ context.Context, orgID int6
 }
 
 func (f *fakeConfigStore) GetHistoricalConfiguration(_ context.Context, orgID int64, id int64) (*models.HistoricAlertConfiguration, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
 	configsByOrg, ok := f.historicConfigs[orgID]
 	if !ok {
 		return &models.HistoricAlertConfiguration{}, store.ErrNoAlertmanagerConfiguration

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -45,7 +45,7 @@ const (
 }
 `
 	alertingDefaultInitializationTimeout       = 30 * time.Second // LOGZ.IO GRAFANA CHANGE :: DEV-48976 - Make context deadline on AlertNG service startup configurable - cherrypick from: 1fdc48fabafe8b8480a58fb4a169d01ebb535fb2
-	alertmanagerDefaultSyncConcurrency         = 10               // LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync
+	alertmanagerDefaultSyncConcurrency         = 10
 	evaluatorDefaultEvaluationTimeout          = 30 * time.Second
 	schedulerDefaultAdminConfigPollInterval    = time.Minute
 	schedulereDefaultExecuteAlerts             = true
@@ -85,7 +85,7 @@ type UnifiedAlertingSettings struct {
 	HARedisDB                      int
 	HARedisMaxConns                int
 	InitializationTimeout          time.Duration
-	SyncConcurrency                int // LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Number of orgs whose Alertmanagers are initialized concurrently during sync
+	SyncConcurrency                int
 	MaxAttempts                    int64
 	MinInterval                    time.Duration
 	EvaluationTimeout              time.Duration
@@ -246,12 +246,10 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 		return err
 	}
 
-	// LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync
 	uaCfg.SyncConcurrency = ua.Key("alertmanager_sync_concurrency").MustInt(alertmanagerDefaultSyncConcurrency)
 	if uaCfg.SyncConcurrency < 1 {
 		uaCfg.SyncConcurrency = 1
 	}
-	// LOGZ.IO GRAFANA CHANGE :: End
 
 	uaCfg.AdminConfigPollInterval, err = gtime.ParseDuration(valueAsString(ua, "admin_config_poll_interval", (schedulerDefaultAdminConfigPollInterval).String()))
 	if err != nil {

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -45,6 +45,7 @@ const (
 }
 `
 	alertingDefaultInitializationTimeout       = 30 * time.Second // LOGZ.IO GRAFANA CHANGE :: DEV-48976 - Make context deadline on AlertNG service startup configurable - cherrypick from: 1fdc48fabafe8b8480a58fb4a169d01ebb535fb2
+	alertmanagerDefaultSyncConcurrency         = 10               // LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync
 	evaluatorDefaultEvaluationTimeout          = 30 * time.Second
 	schedulerDefaultAdminConfigPollInterval    = time.Minute
 	schedulereDefaultExecuteAlerts             = true
@@ -84,6 +85,7 @@ type UnifiedAlertingSettings struct {
 	HARedisDB                      int
 	HARedisMaxConns                int
 	InitializationTimeout          time.Duration
+	SyncConcurrency                int // LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Number of orgs whose Alertmanagers are initialized concurrently during sync
 	MaxAttempts                    int64
 	MinInterval                    time.Duration
 	EvaluationTimeout              time.Duration
@@ -243,6 +245,13 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	if err != nil {
 		return err
 	}
+
+	// LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync
+	uaCfg.SyncConcurrency = ua.Key("alertmanager_sync_concurrency").MustInt(alertmanagerDefaultSyncConcurrency)
+	if uaCfg.SyncConcurrency < 1 {
+		uaCfg.SyncConcurrency = 1
+	}
+	// LOGZ.IO GRAFANA CHANGE :: End
 
 	uaCfg.AdminConfigPollInterval, err = gtime.ParseDuration(valueAsString(ua, "admin_config_poll_interval", (schedulerDefaultAdminConfigPollInterval).String()))
 	if err != nil {

--- a/pkg/setting/setting_unified_alerting_test.go
+++ b/pkg/setting/setting_unified_alerting_test.go
@@ -26,7 +26,7 @@ func TestCfg_ReadUnifiedAlertingSettings(t *testing.T) {
 		require.Equal(t, 200*time.Millisecond, cfg.UnifiedAlerting.HAGossipInterval)
 		require.Equal(t, time.Minute, cfg.UnifiedAlerting.HAPushPullInterval)
 		require.Equal(t, alertingDefaultInitializationTimeout, cfg.UnifiedAlerting.InitializationTimeout) // LOGZ.IO GRAFANA CHANGE :: DEV-48976 - Make context deadline on AlertNG service startup configurable - cherrypick from: 1fdc48fabafe8b8480a58fb4a169d01ebb535fb2
-		require.Equal(t, alertmanagerDefaultSyncConcurrency, cfg.UnifiedAlerting.SyncConcurrency)        // LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync
+		require.Equal(t, alertmanagerDefaultSyncConcurrency, cfg.UnifiedAlerting.SyncConcurrency)
 	}
 
 	// With peers set, it correctly parses them.
@@ -40,19 +40,17 @@ func TestCfg_ReadUnifiedAlertingSettings(t *testing.T) {
 		_, err = s.NewKey("initialization_timeout", "123s")
 		require.NoError(t, err)
 		// LOGZ.IO GRAFANA CHANGE :: End
-		// LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync
 		_, err = s.NewKey("alertmanager_sync_concurrency", "25")
 		require.NoError(t, err)
-		// LOGZ.IO GRAFANA CHANGE :: End
 
 		require.NoError(t, cfg.ReadUnifiedAlertingSettings(cfg.Raw))
 		require.Len(t, cfg.UnifiedAlerting.HAPeers, 3)
 		require.ElementsMatch(t, []string{"hostname1:9090", "hostname2:9090", "hostname3:9090"}, cfg.UnifiedAlerting.HAPeers)
 		require.Equal(t, 123*time.Second, cfg.UnifiedAlerting.InitializationTimeout) // LOGZ.IO GRAFANA CHANGE :: DEV-48976 - Make context deadline on AlertNG service startup configurable - cherrypick from: 1fdc48fabafe8b8480a58fb4a169d01ebb535fb2
-		require.Equal(t, 25, cfg.UnifiedAlerting.SyncConcurrency)                     // LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync
+		require.Equal(t, 25, cfg.UnifiedAlerting.SyncConcurrency)
 	}
 
-	// LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync. A non-positive concurrency is floored to 1.
+	// A non-positive concurrency is floored to 1.
 	{
 		s, err := cfg.Raw.NewSection("unified_alerting")
 		require.NoError(t, err)
@@ -62,7 +60,6 @@ func TestCfg_ReadUnifiedAlertingSettings(t *testing.T) {
 		require.NoError(t, cfg.ReadUnifiedAlertingSettings(cfg.Raw))
 		require.Equal(t, 1, cfg.UnifiedAlerting.SyncConcurrency)
 	}
-	// LOGZ.IO GRAFANA CHANGE :: End
 
 	t.Run("should read 'scheduler_tick_interval'", func(t *testing.T) {
 		tmp := cfg.IsFeatureToggleEnabled

--- a/pkg/setting/setting_unified_alerting_test.go
+++ b/pkg/setting/setting_unified_alerting_test.go
@@ -26,6 +26,7 @@ func TestCfg_ReadUnifiedAlertingSettings(t *testing.T) {
 		require.Equal(t, 200*time.Millisecond, cfg.UnifiedAlerting.HAGossipInterval)
 		require.Equal(t, time.Minute, cfg.UnifiedAlerting.HAPushPullInterval)
 		require.Equal(t, alertingDefaultInitializationTimeout, cfg.UnifiedAlerting.InitializationTimeout) // LOGZ.IO GRAFANA CHANGE :: DEV-48976 - Make context deadline on AlertNG service startup configurable - cherrypick from: 1fdc48fabafe8b8480a58fb4a169d01ebb535fb2
+		require.Equal(t, alertmanagerDefaultSyncConcurrency, cfg.UnifiedAlerting.SyncConcurrency)        // LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync
 	}
 
 	// With peers set, it correctly parses them.
@@ -39,12 +40,29 @@ func TestCfg_ReadUnifiedAlertingSettings(t *testing.T) {
 		_, err = s.NewKey("initialization_timeout", "123s")
 		require.NoError(t, err)
 		// LOGZ.IO GRAFANA CHANGE :: End
+		// LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync
+		_, err = s.NewKey("alertmanager_sync_concurrency", "25")
+		require.NoError(t, err)
+		// LOGZ.IO GRAFANA CHANGE :: End
 
 		require.NoError(t, cfg.ReadUnifiedAlertingSettings(cfg.Raw))
 		require.Len(t, cfg.UnifiedAlerting.HAPeers, 3)
 		require.ElementsMatch(t, []string{"hostname1:9090", "hostname2:9090", "hostname3:9090"}, cfg.UnifiedAlerting.HAPeers)
 		require.Equal(t, 123*time.Second, cfg.UnifiedAlerting.InitializationTimeout) // LOGZ.IO GRAFANA CHANGE :: DEV-48976 - Make context deadline on AlertNG service startup configurable - cherrypick from: 1fdc48fabafe8b8480a58fb4a169d01ebb535fb2
+		require.Equal(t, 25, cfg.UnifiedAlerting.SyncConcurrency)                     // LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync
 	}
+
+	// LOGZ.IO GRAFANA CHANGE :: APPZ-1782 - Parallelize per-org Alertmanager sync. A non-positive concurrency is floored to 1.
+	{
+		s, err := cfg.Raw.NewSection("unified_alerting")
+		require.NoError(t, err)
+		_, err = s.NewKey("alertmanager_sync_concurrency", "0")
+		require.NoError(t, err)
+
+		require.NoError(t, cfg.ReadUnifiedAlertingSettings(cfg.Raw))
+		require.Equal(t, 1, cfg.UnifiedAlerting.SyncConcurrency)
+	}
+	// LOGZ.IO GRAFANA CHANGE :: End
 
 	t.Run("should read 'scheduler_tick_interval'", func(t *testing.T) {
 		tmp := cfg.IsFeatureToggleEnabled


### PR DESCRIPTION
## Why

grafana-x startup time grows **O(n)** in the number of orgs: `MultiOrgAlertmanager.SyncAlertmanagersForOrgs` initializes each org's Alertmanager (`factory()` + `ApplyConfig()`) **serially** under one lock. On `am-prod-us-east-1-*` this currently peaks at **~300–400s**, against the deployed `initialization_timeout` of **500s** (60–80% of the ceiling). Beyond that, the alert-manager fails to start — the original incident ([APPZ-1782](https://logzio.atlassian.net/browse/APPZ-1782)).

The timeout bump (Phase 1) was a band-aid and Phase 2 ("global default config") was found infeasible without forking deeper. This is the agreed structural fix (Yasmin / Paulina in the ticket): parallelize the per-org loop.

## What

- **Parallelize the per-org work** with a bounded `errgroup`:
  - Phase A (concurrent): `factory()` + `ApplyConfig()` per org, written into index-aligned slots — no shared-map mutation, no synchronization.
  - Phase B (serial, fast, no I/O): merge results + prune removed orgs under the write lock.
  - Turns the dominant cost from O(n) into ~O(n / concurrency). Each alert-manager replica initializes all orgs (no sharding), so every replica benefits.
- **New setting** `[unified_alerting] alertmanager_sync_concurrency` (default `10`, floored to `1`). Guarded **in-code** too, because `errgroup.SetLimit(0)` would block every goroutine forever and the MOA can be built with a raw `Cfg`.
- **Info-level log** at end of sync with `org_count` + `duration_seconds` (was Debug, duration only) so the per-restart cost is visible without enabling debug logging.
- **Thread-safe `fakeConfigStore`** — the real store is concurrency-safe; the fake had to be too now that the path runs concurrently (otherwise `-race` flags the fake, not prod code).

Behavior is preserved exactly: same orgs created/updated/stopped, same "log and skip" error handling — including registering a newly-created Alertmanager even when its config fails to apply (leaving a not-ready AM in the map, as before).

## Concurrency safety

Per-org work touches only independent state: per-org working dir, per-org kvStore namespace, per-org metrics registry (`GetOrCreateOrgRegistry` is documented "safe to call concurrently"), and each AM's own `Base.WithLock`. Shared deps (`store`, `kvStore`, `decryptFn`, `ns`, `peer`) are built for concurrent multi-request use.

## Testing

- `go test -race ./pkg/services/ngalert/notifier/ ./pkg/setting/` — pass.
- New timing test: 20 orgs, concurrency 1 vs 10 → **~8.6× faster** (728ms → 84ms); asserts a conservative >2× to stay CI-robust.
- New settings test: default `10`, ini override, and the `<1 → 1` floor.

## Verifying the win in prod

Compare before/after at the same org count via the `grafana_alerting_sync_alertmanagers_time_seconds` metric (AI-40) on `am-prod-<region>-*`, e.g. `max_over_time(grafana_alerting_sync_alertmanagers_time_seconds{region="us-east-1"}[15m])` right after a restart, alongside `grafana_alerting_discovered_configurations` (n). The new Info log `"Done synchronizing Alertmanagers for orgs"` (with `org_count`/`duration_seconds`) gives the same numbers in logs.

[APPZ-1782]: https://logzio.atlassian.net/browse/APPZ-1782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ