### PR TITLE
APPZ-1782 - Log alertmanager sync phase timings and effective concurrency

### DIFF
--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -237,11 +237,16 @@ func (moa *MultiOrgAlertmanager) LoadAndSyncAlertmanagersForOrgs(ctx context.Con
 
 	// Then, sync them by creating or deleting Alertmanagers as necessary.
 	moa.metrics.DiscoveredConfigurations.Set(float64(len(orgIDs)))
-	timings := moa.SyncAlertmanagersForOrgs(ctx, orgIDs)
+	timings, err := moa.SyncAlertmanagersForOrgs(ctx, orgIDs)
 
 	// LOGZ.IO GRAFANA CHANGE :: AI-40 - Add observability to alertmanagers load time
 	loadingTime := time.Since(startTime).Seconds()
 	moa.metrics.SyncAlertmanagersTimeSeconds.Set(loadingTime)
+	if err != nil {
+		// Failure already logged in SyncAlertmanagersForOrgs; skip the misleading "Done" line.
+		// Return nil to preserve the existing non-fatal behavior on the init/poll paths.
+		return nil
+	}
 	moa.logger.Info("Done synchronizing Alertmanagers for orgs",
 		"org_count", len(orgIDs),
 		"duration_seconds", loadingTime,
@@ -280,14 +285,14 @@ type syncPhaseTimings struct {
 }
 
 // SyncAlertmanagersForOrgs syncs configuration of the Alertmanager required by each organization.
-func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, orgIDs []int64) syncPhaseTimings {
+func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, orgIDs []int64) (syncPhaseTimings, error) {
 	var timings syncPhaseTimings
 	orgsFound := make(map[int64]struct{}, len(orgIDs))
 	loadConfigsStart := time.Now()
 	dbConfigs, err := moa.getLatestConfigs(ctx)
 	if err != nil {
 		moa.logger.Error("Failed to load Alertmanager configurations", "error", err)
-		return timings
+		return timings, err
 	}
 	timings.loadConfigsSeconds = time.Since(loadConfigsStart).Seconds()
 	// Snapshot the running Alertmanagers under a read lock so the per-org work below can run concurrently
@@ -396,7 +401,7 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 	moa.cleanupOrphanLocalOrgState(ctx, orgsFound)
 	timings.cleanupSeconds = time.Since(cleanupStart).Seconds()
 
-	return timings
+	return timings, nil
 }
 
 // cleanupOrphanLocalOrgState will check if there is any organization on

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -237,12 +237,19 @@ func (moa *MultiOrgAlertmanager) LoadAndSyncAlertmanagersForOrgs(ctx context.Con
 
 	// Then, sync them by creating or deleting Alertmanagers as necessary.
 	moa.metrics.DiscoveredConfigurations.Set(float64(len(orgIDs)))
-	moa.SyncAlertmanagersForOrgs(ctx, orgIDs)
+	timings := moa.SyncAlertmanagersForOrgs(ctx, orgIDs)
 
 	// LOGZ.IO GRAFANA CHANGE :: AI-40 - Add observability to alertmanagers load time
 	loadingTime := time.Since(startTime).Seconds()
 	moa.metrics.SyncAlertmanagersTimeSeconds.Set(loadingTime)
-	moa.logger.Info("Done synchronizing Alertmanagers for orgs", "org_count", len(orgIDs), "duration_seconds", loadingTime)
+	moa.logger.Info("Done synchronizing Alertmanagers for orgs",
+		"org_count", len(orgIDs),
+		"duration_seconds", loadingTime,
+		"load_configs_seconds", timings.loadConfigsSeconds,
+		"sync_loop_seconds", timings.syncLoopSeconds,
+		"cleanup_seconds", timings.cleanupSeconds,
+		"concurrency", timings.concurrency,
+	)
 	// LOGZ.IO GRAFANA CHANGE :: End
 
 	return nil
@@ -263,14 +270,26 @@ func (moa *MultiOrgAlertmanager) getLatestConfigs(ctx context.Context) (map[int6
 	return result, nil
 }
 
+// syncPhaseTimings breaks down where a sync spends time so the dominant phase (config load,
+// the per-org sync loop, or orphan cleanup) is visible in the completion log.
+type syncPhaseTimings struct {
+	loadConfigsSeconds float64
+	syncLoopSeconds    float64
+	cleanupSeconds     float64
+	concurrency        int
+}
+
 // SyncAlertmanagersForOrgs syncs configuration of the Alertmanager required by each organization.
-func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, orgIDs []int64) {
+func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, orgIDs []int64) syncPhaseTimings {
+	var timings syncPhaseTimings
 	orgsFound := make(map[int64]struct{}, len(orgIDs))
+	loadConfigsStart := time.Now()
 	dbConfigs, err := moa.getLatestConfigs(ctx)
 	if err != nil {
 		moa.logger.Error("Failed to load Alertmanager configurations", "error", err)
-		return
+		return timings
 	}
+	timings.loadConfigsSeconds = time.Since(loadConfigsStart).Seconds()
 	// Snapshot the running Alertmanagers under a read lock so the per-org work below can run concurrently
 	// without holding the lock. This method is the only writer of moa.alertmanagers and runs serially.
 	moa.alertmanagersMtx.RLock()
@@ -300,7 +319,9 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 	if concurrency < 1 {
 		concurrency = 1
 	}
+	timings.concurrency = concurrency
 	g.SetLimit(concurrency)
+	loopStart := time.Now()
 	for i, orgID := range syncOrgs {
 		i, orgID := i, orgID
 		g.Go(func() error {
@@ -338,6 +359,7 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 		})
 	}
 	_ = g.Wait() // goroutines never return an error; failures are logged above and the org is skipped.
+	timings.syncLoopSeconds = time.Since(loopStart).Seconds()
 
 	// Merge results and prune removed orgs under the write lock. This phase is fast and does no I/O.
 	moa.alertmanagersMtx.Lock()
@@ -358,6 +380,7 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 	moa.metrics.ActiveConfigurations.Set(float64(len(moa.alertmanagers)))
 	moa.alertmanagersMtx.Unlock()
 
+	cleanupStart := time.Now()
 	// Now, we can stop the Alertmanagers without having to hold a lock.
 	for orgID, am := range amsToStop {
 		moa.logger.Info("Stopping Alertmanager", "org", orgID)
@@ -371,6 +394,9 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 	// occur when an organization is deleted and the node running Grafana is
 	// shutdown before the next sync is executed.
 	moa.cleanupOrphanLocalOrgState(ctx, orgsFound)
+	timings.cleanupSeconds = time.Since(cleanupStart).Seconds()
+
+	return timings
 }
 
 // cleanupOrphanLocalOrgState will check if there is any organization on

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
@@ -223,6 +223,44 @@ func TestMultiOrgAlertmanager_SyncAlertmanagersConcurrency(t *testing.T) {
 	require.Less(t, parallel, serial/2, "expected concurrent sync to be at least 2x faster than serial")
 }
 
+// TestMultiOrgAlertmanager_SyncAlertmanagersForOrgs_PhaseTimings verifies that SyncAlertmanagersForOrgs
+// reports the effective concurrency (so the configured value is observable) and populates phase timings.
+func TestMultiOrgAlertmanager_SyncAlertmanagersForOrgs_PhaseTimings(t *testing.T) {
+	newMam := func(concurrency int) *MultiOrgAlertmanager {
+		configStore := NewFakeConfigStore(t, map[int64]*models.AlertConfiguration{})
+		orgStore := &FakeOrgStore{orgs: []int64{1, 2, 3}}
+		kvStore := ngfakes.NewFakeKVStore(t)
+		provStore := ngfakes.NewFakeProvisioningStore()
+		secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
+		reg := prometheus.NewPedanticRegistry()
+		m := metrics.NewNGAlert(reg)
+		cfg := &setting.Cfg{
+			DataPath: t.TempDir(),
+			UnifiedAlerting: setting.UnifiedAlertingSettings{
+				AlertmanagerConfigPollInterval: 3 * time.Minute,
+				DefaultConfiguration:           setting.GetAlertmanagerDefaultConfiguration(),
+				SyncConcurrency:                concurrency,
+			},
+		}
+		mam, err := NewMultiOrgAlertmanager(cfg, configStore, orgStore, kvStore, provStore, secretsService.GetDecryptedValue, m.GetMultiOrgAlertmanagerMetrics(), nil, log.New("testlogger"), secretsService, &featuremgmt.FeatureManager{})
+		require.NoError(t, err)
+		return mam
+	}
+
+	t.Run("reports the configured concurrency and populates timings", func(t *testing.T) {
+		timings := newMam(7).SyncAlertmanagersForOrgs(context.Background(), []int64{1, 2, 3})
+		require.Equal(t, 7, timings.concurrency)
+		require.GreaterOrEqual(t, timings.loadConfigsSeconds, 0.0)
+		require.GreaterOrEqual(t, timings.syncLoopSeconds, 0.0)
+		require.GreaterOrEqual(t, timings.cleanupSeconds, 0.0)
+	})
+
+	t.Run("floors non-positive concurrency to 1", func(t *testing.T) {
+		timings := newMam(0).SyncAlertmanagersForOrgs(context.Background(), []int64{1})
+		require.Equal(t, 1, timings.concurrency)
+	})
+}
+
 func TestMultiOrgAlertmanager_SyncAlertmanagersForOrgsWithFailures(t *testing.T) {
 	// Include a broken configuration for organization 2.
 	var orgWithBadConfig int64 = 2

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
@@ -248,7 +248,8 @@ func TestMultiOrgAlertmanager_SyncAlertmanagersForOrgs_PhaseTimings(t *testing.T
 	}
 
 	t.Run("reports the configured concurrency and populates timings", func(t *testing.T) {
-		timings := newMam(7).SyncAlertmanagersForOrgs(context.Background(), []int64{1, 2, 3})
+		timings, err := newMam(7).SyncAlertmanagersForOrgs(context.Background(), []int64{1, 2, 3})
+		require.NoError(t, err)
 		require.Equal(t, 7, timings.concurrency)
 		require.GreaterOrEqual(t, timings.loadConfigsSeconds, 0.0)
 		require.GreaterOrEqual(t, timings.syncLoopSeconds, 0.0)
@@ -256,7 +257,8 @@ func TestMultiOrgAlertmanager_SyncAlertmanagersForOrgs_PhaseTimings(t *testing.T
 	})
 
 	t.Run("floors non-positive concurrency to 1", func(t *testing.T) {
-		timings := newMam(0).SyncAlertmanagersForOrgs(context.Background(), []int64{1})
+		timings, err := newMam(0).SyncAlertmanagersForOrgs(context.Background(), []int64{1})
+		require.NoError(t, err)
 		require.Equal(t, 1, timings.concurrency)
 	})
 }


### PR DESCRIPTION
## Why

Follow-up to #128 (parallelized per-org Alertmanager sync). In prod (us-east-1, ~6000 orgs) the sync takes ~177s, and raising `alertmanager_sync_concurrency` from 10→20 made **no difference** — which means the per-org loop is no longer the bottleneck and a **serial phase** (config load or orphan cleanup) likely dominates. But the completion log only reported the *total* `duration_seconds`, so there was no way to see the breakdown or even confirm the effective concurrency.

## What

`SyncAlertmanagersForOrgs` now returns per-phase timings, and the existing `"Done synchronizing Alertmanagers for orgs"` Info log is enriched with:

- `load_configs_seconds` — `getLatestConfigs` (loads/deserializes all per-org configs, serial)
- `sync_loop_seconds` — the bounded-concurrency per-org factory + ApplyConfig loop
- `cleanup_seconds` — stopping removed orgs' Alertmanagers + `cleanupOrphanLocalOrgState`
- `concurrency` — the **effective** `alertmanager_sync_concurrency` (so it's no longer a guess whether the setting/env took effect)

No behavior change — purely observability. Only direct caller of `SyncAlertmanagersForOrgs` is `LoadAndSyncAlertmanagersForOrgs`.

## How it helps

Next time we look at a slow sync, the log immediately shows which phase owns the time, so we optimize the real bottleneck instead of tuning a knob that doesn't move the needle. It also makes the deployed concurrency value visible for support/DoD.

## Testing

- `go test -race ./pkg/services/ngalert/notifier/` — pass.
- New `TestMultiOrgAlertmanager_SyncAlertmanagersForOrgs_PhaseTimings`: asserts the returned `concurrency` reflects the configured value (7) and is floored to 1 for a non-positive setting, and that the phase timings are populated.