### PR TITLE
APPZ-1782 - Cut grafana-x-alert-manager startup time (skip warm-up config-applied writes + observability)

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -377,9 +377,7 @@ func (am *alertmanager) applyConfig(cfg *apimodels.PostableUserConfig) (bool, er
 type skipMarkConfigAppliedKey struct{}
 
 // WithSkipMarkConfigApplied returns a context that tells ApplyConfig not to write the
-// MarkConfigurationAsApplied record. Used for the initial warm-up sync, where a fresh Alertmanager
-// re-applies every org's existing config and marking all of them would be a per-org DB write storm
-// on the shared database for configs that did not actually change.
+// MarkConfigurationAsApplied record (used by the warm-up sync; see SyncAlertmanagersForOrgs).
 func WithSkipMarkConfigApplied(ctx context.Context) context.Context {
 	return context.WithValue(ctx, skipMarkConfigAppliedKey{}, true)
 }

--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -373,6 +373,22 @@ func (am *alertmanager) applyConfig(cfg *apimodels.PostableUserConfig) (bool, er
 	return true, nil
 }
 
+// skipMarkConfigAppliedKey is the context key that suppresses the "configuration applied" DB write.
+type skipMarkConfigAppliedKey struct{}
+
+// WithSkipMarkConfigApplied returns a context that tells ApplyConfig not to write the
+// MarkConfigurationAsApplied record. Used for the initial warm-up sync, where a fresh Alertmanager
+// re-applies every org's existing config and marking all of them would be a per-org DB write storm
+// on the shared database for configs that did not actually change.
+func WithSkipMarkConfigApplied(ctx context.Context) context.Context {
+	return context.WithValue(ctx, skipMarkConfigAppliedKey{}, true)
+}
+
+func skipMarkConfigApplied(ctx context.Context) bool {
+	skip, _ := ctx.Value(skipMarkConfigAppliedKey{}).(bool)
+	return skip
+}
+
 // applyAndMarkConfig applies a configuration and marks it as applied if no errors occur.
 func (am *alertmanager) applyAndMarkConfig(ctx context.Context, hash string, cfg *apimodels.PostableUserConfig) error {
 	configChanged, err := am.applyConfig(cfg)
@@ -380,7 +396,7 @@ func (am *alertmanager) applyAndMarkConfig(ctx context.Context, hash string, cfg
 		return err
 	}
 
-	if configChanged {
+	if configChanged && !skipMarkConfigApplied(ctx) {
 		markConfigCmd := ngmodels.MarkConfigurationAsAppliedCmd{
 			OrgID:             am.orgID,
 			ConfigurationHash: hash,

--- a/pkg/services/ngalert/notifier/file_store.go
+++ b/pkg/services/ngalert/notifier/file_store.go
@@ -16,6 +16,21 @@ import (
 
 const KVNamespace = "alertmanager"
 
+// preloadedFileStateKey is the context key for a bulk-loaded snapshot of Alertmanager file state.
+type preloadedFileStateKey struct{}
+
+// WithPreloadedFileState returns a context carrying a bulk-loaded snapshot of Alertmanager file
+// state (orgID -> filename -> base64 content). When present, FilepathFor hydrates from it instead
+// of issuing a per-org kvstore read. See MultiOrgAlertmanager.SyncAlertmanagersForOrgs.
+func WithPreloadedFileState(ctx context.Context, state map[int64]map[string]string) context.Context {
+	return context.WithValue(ctx, preloadedFileStateKey{}, state)
+}
+
+func preloadedFileStateFromContext(ctx context.Context) (map[int64]map[string]string, bool) {
+	state, ok := ctx.Value(preloadedFileStateKey{}).(map[int64]map[string]string)
+	return state, ok
+}
+
 // FileStore is in charge of persisting the alertmanager files to the database.
 // It uses the KVstore table and encodes the files as a base64 string.
 type FileStore struct {
@@ -40,7 +55,7 @@ func NewFileStore(orgID int64, store kvstore.KVStore, workingDirPath string) *Fi
 // If there is a file in the database, it decodes it and writes to disk for Alertmanager consumption.
 func (fileStore *FileStore) FilepathFor(ctx context.Context, filename string) (string, error) {
 	// Then, let's attempt to read it from the database.
-	content, exists, err := fileStore.kv.Get(ctx, filename)
+	content, exists, err := fileStore.readContent(ctx, filename)
 	if err != nil {
 		return "", fmt.Errorf("error reading file '%s' from database: %w", filename, err)
 	}
@@ -61,6 +76,17 @@ func (fileStore *FileStore) FilepathFor(ctx context.Context, filename string) (s
 	}
 
 	return fileStore.pathFor(filename), err
+}
+
+// readContent returns the stored (base64) content for a file. If the context carries a bulk-loaded
+// state snapshot (WithPreloadedFileState), it is used to avoid a per-org kvstore read; that snapshot
+// is authoritative, so an absent org/key means "no stored file". Otherwise it reads the single key directly.
+func (fileStore *FileStore) readContent(ctx context.Context, filename string) (string, bool, error) {
+	if state, ok := preloadedFileStateFromContext(ctx); ok {
+		content, exists := state[fileStore.orgID][filename]
+		return content, exists, nil
+	}
+	return fileStore.kv.Get(ctx, filename)
 }
 
 // GetFullState receives a list of keys, looks for the corresponding values in the kvstore,

--- a/pkg/services/ngalert/notifier/file_store_test.go
+++ b/pkg/services/ngalert/notifier/file_store_test.go
@@ -76,6 +76,41 @@ func TestFileStore_FilepathFor(t *testing.T) {
 	}
 }
 
+func TestFileStore_FilepathFor_PreloadedState(t *testing.T) {
+	store := fakes.NewFakeKVStore(t)
+	workingDir := t.TempDir()
+	fs := NewFileStore(1, store, workingDir)
+	filekey := "silences"
+	filePath := filepath.Join(workingDir, filekey)
+
+	// Preloaded state for this org is used and written to disk without touching the kvstore
+	// (nothing was Set on the store, so a fallback kv.Get would find nothing and write no file).
+	{
+		ctx := WithPreloadedFileState(context.Background(), map[int64]map[string]string{
+			1: {filekey: encode([]byte("silence-from-preload"))},
+		})
+		r, err := fs.FilepathFor(ctx, filekey)
+		require.NoError(t, err)
+		require.Equal(t, filePath, r)
+		f, err := os.ReadFile(filepath.Clean(filePath))
+		require.NoError(t, err)
+		require.Equal(t, "silence-from-preload", string(f))
+		require.NoError(t, os.Remove(filePath))
+	}
+
+	// Preloaded state present but this org has no entry: no-op, no file written.
+	{
+		ctx := WithPreloadedFileState(context.Background(), map[int64]map[string]string{
+			2: {filekey: encode([]byte("other-org"))},
+		})
+		r, err := fs.FilepathFor(ctx, filekey)
+		require.NoError(t, err)
+		require.Equal(t, filePath, r)
+		_, err = os.ReadFile(filepath.Clean(filePath))
+		require.Error(t, err)
+	}
+}
+
 func TestFileStore_GetFullState(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -251,6 +251,7 @@ func (moa *MultiOrgAlertmanager) LoadAndSyncAlertmanagersForOrgs(ctx context.Con
 		"org_count", len(orgIDs),
 		"duration_seconds", loadingTime,
 		"load_configs_seconds", timings.loadConfigsSeconds,
+		"preload_state_seconds", timings.preloadStateSeconds,
 		"sync_loop_seconds", timings.syncLoopSeconds,
 		"cleanup_seconds", timings.cleanupSeconds,
 		"concurrency", timings.concurrency,
@@ -278,10 +279,11 @@ func (moa *MultiOrgAlertmanager) getLatestConfigs(ctx context.Context) (map[int6
 // syncPhaseTimings breaks down where a sync spends time so the dominant phase (config load,
 // the per-org sync loop, or orphan cleanup) is visible in the completion log.
 type syncPhaseTimings struct {
-	loadConfigsSeconds float64
-	syncLoopSeconds    float64
-	cleanupSeconds     float64
-	concurrency        int
+	loadConfigsSeconds  float64
+	preloadStateSeconds float64
+	syncLoopSeconds     float64
+	cleanupSeconds      float64
+	concurrency         int
 }
 
 // SyncAlertmanagersForOrgs syncs configuration of the Alertmanager required by each organization.
@@ -295,6 +297,17 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 		return timings, err
 	}
 	timings.loadConfigsSeconds = time.Since(loadConfigsStart).Seconds()
+
+	// Bulk-load every org's Alertmanager file state (notification log + silences) in one query so the
+	// per-org factory below hydrates from memory instead of issuing 2 kvstore reads per org, which was
+	// the dominant cost of the sync loop. Falls back to per-org reads if the bulk load fails.
+	preloadStart := time.Now()
+	if fileState, err := moa.kvStore.GetAll(ctx, kvstore.AllOrganizations, KVNamespace); err != nil {
+		moa.logger.Warn("Failed to bulk-load Alertmanager file state; falling back to per-org reads", "error", err)
+	} else {
+		ctx = WithPreloadedFileState(ctx, fileState)
+	}
+	timings.preloadStateSeconds = time.Since(preloadStart).Seconds()
 	// Snapshot the running Alertmanagers under a read lock so the per-org work below can run concurrently
 	// without holding the lock. This method is the only writer of moa.alertmanagers and runs serially.
 	moa.alertmanagersMtx.RLock()

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -70,6 +70,10 @@ type MultiOrgAlertmanager struct {
 	alertmanagersMtx sync.RWMutex
 	alertmanagers    map[int64]Alertmanager
 
+	// warmedUp is false until the first sync; the first (warm-up) sync skips the per-org
+	// MarkConfigurationAsApplied DB write, which would otherwise be a write storm at startup.
+	warmedUp atomic.Bool
+
 	settings       *setting.Cfg
 	featureManager featuremgmt.FeatureToggles
 	logger         log.Logger
@@ -258,6 +262,7 @@ func (moa *MultiOrgAlertmanager) LoadAndSyncAlertmanagersForOrgs(ctx context.Con
 		"apply_config_seconds_total", timings.applyConfigSeconds,
 		"cleanup_seconds", timings.cleanupSeconds,
 		"concurrency", timings.concurrency,
+		"warmup", timings.warmUp,
 	)
 	// LOGZ.IO GRAFANA CHANGE :: End
 
@@ -287,6 +292,7 @@ type syncPhaseTimings struct {
 	syncLoopSeconds     float64
 	cleanupSeconds      float64
 	concurrency         int
+	warmUp              bool
 	// factorySeconds and applyConfigSeconds are aggregate work-seconds summed across all concurrent
 	// workers (so they exceed wall-clock); their ratio shows which step dominates the sync loop, and
 	// each divided by concurrency approximates its wall-clock contribution.
@@ -316,6 +322,15 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 		ctx = WithPreloadedFileState(ctx, fileState)
 	}
 	timings.preloadStateSeconds = time.Since(preloadStart).Seconds()
+
+	// On the first (warm-up) sync every org's config is re-applied to a fresh Alertmanager, so it all
+	// looks "changed" and each org would issue a MarkConfigurationAsApplied write — a per-org write storm
+	// on the shared DB for configs that didn't actually change. Skip the marker on that first sync only.
+	timings.warmUp = moa.warmedUp.CompareAndSwap(false, true)
+	if timings.warmUp {
+		ctx = WithSkipMarkConfigApplied(ctx)
+	}
+
 	// Snapshot the running Alertmanagers under a read lock so the per-org work below can run concurrently
 	// without holding the lock. This method is the only writer of moa.alertmanagers and runs serially.
 	moa.alertmanagersMtx.RLock()

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	alertingCluster "github.com/grafana/alerting/cluster"
@@ -253,6 +254,8 @@ func (moa *MultiOrgAlertmanager) LoadAndSyncAlertmanagersForOrgs(ctx context.Con
 		"load_configs_seconds", timings.loadConfigsSeconds,
 		"preload_state_seconds", timings.preloadStateSeconds,
 		"sync_loop_seconds", timings.syncLoopSeconds,
+		"factory_seconds_total", timings.factorySeconds,
+		"apply_config_seconds_total", timings.applyConfigSeconds,
 		"cleanup_seconds", timings.cleanupSeconds,
 		"concurrency", timings.concurrency,
 	)
@@ -284,6 +287,11 @@ type syncPhaseTimings struct {
 	syncLoopSeconds     float64
 	cleanupSeconds      float64
 	concurrency         int
+	// factorySeconds and applyConfigSeconds are aggregate work-seconds summed across all concurrent
+	// workers (so they exceed wall-clock); their ratio shows which step dominates the sync loop, and
+	// each divided by concurrency approximates its wall-clock contribution.
+	factorySeconds     float64
+	applyConfigSeconds float64
 }
 
 // SyncAlertmanagersForOrgs syncs configuration of the Alertmanager required by each organization.
@@ -339,6 +347,8 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 	}
 	timings.concurrency = concurrency
 	g.SetLimit(concurrency)
+	// Aggregate per-org time in the two heavy steps (summed across workers) to reveal which dominates.
+	var factoryNanos, applyConfigNanos atomic.Int64
 	loopStart := time.Now()
 	for i, orgID := range syncOrgs {
 		i, orgID := i, orgID
@@ -348,7 +358,9 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 				// These metrics are not exported by Grafana and are mostly a placeholder.
 				// To export them, we need to translate the metrics from each individual registry and,
 				// then aggregate them on the main registry.
+				factoryStart := time.Now()
 				am, err := moa.factory(ctx, orgID)
+				factoryNanos.Add(int64(time.Since(factoryStart)))
 				if err != nil {
 					moa.logger.Error("Unable to create Alertmanager for org", "org", orgID, "error", err)
 					return nil // synced[i] stays nil: a failed factory means the org is not registered.
@@ -357,6 +369,9 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 			}
 			// Register the AM before applying config: a failed apply must still leave it (not-ready) in the map.
 			synced[i] = alertmanager
+
+			applyStart := time.Now()
+			defer func() { applyConfigNanos.Add(int64(time.Since(applyStart))) }()
 
 			dbConfig, cfgFound := dbConfigs[orgID]
 			if !cfgFound {
@@ -378,6 +393,8 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 	}
 	_ = g.Wait() // goroutines never return an error; failures are logged above and the org is skipped.
 	timings.syncLoopSeconds = time.Since(loopStart).Seconds()
+	timings.factorySeconds = float64(factoryNanos.Load()) / float64(time.Second)
+	timings.applyConfigSeconds = float64(applyConfigNanos.Load()) / float64(time.Second)
 
 	// Merge results and prune removed orgs under the write lock. This phase is fast and does no I/O.
 	moa.alertmanagersMtx.Lock()

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -70,8 +70,8 @@ type MultiOrgAlertmanager struct {
 	alertmanagersMtx sync.RWMutex
 	alertmanagers    map[int64]Alertmanager
 
-	// warmedUp is false until the first sync; the first (warm-up) sync skips the per-org
-	// MarkConfigurationAsApplied DB write, which would otherwise be a write storm at startup.
+	// warmedUp is false until the first sync completes; the warm-up sync does extra work — see
+	// SyncAlertmanagersForOrgs.
 	warmedUp atomic.Bool
 
 	settings       *setting.Cfg
@@ -312,22 +312,25 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 	}
 	timings.loadConfigsSeconds = time.Since(loadConfigsStart).Seconds()
 
-	// Bulk-load every org's Alertmanager file state (notification log + silences) in one query so the
-	// per-org factory below hydrates from memory instead of issuing 2 kvstore reads per org, which was
-	// the dominant cost of the sync loop. Falls back to per-org reads if the bulk load fails.
-	preloadStart := time.Now()
-	if fileState, err := moa.kvStore.GetAll(ctx, kvstore.AllOrganizations, KVNamespace); err != nil {
-		moa.logger.Warn("Failed to bulk-load Alertmanager file state; falling back to per-org reads", "error", err)
-	} else {
-		ctx = WithPreloadedFileState(ctx, fileState)
-	}
-	timings.preloadStateSeconds = time.Since(preloadStart).Seconds()
-
-	// On the first (warm-up) sync every org's config is re-applied to a fresh Alertmanager, so it all
-	// looks "changed" and each org would issue a MarkConfigurationAsApplied write — a per-org write storm
-	// on the shared DB for configs that didn't actually change. Skip the marker on that first sync only.
+	// The first (warm-up) sync is the only one that constructs an Alertmanager for every org, and it's
+	// where startup cost concentrates. Two things happen only on that sync:
+	//  1. Bulk-load all orgs' file state in one query so the factory hydrates from memory instead of a
+	//     per-org kvstore read (the factory reads it via FilepathFor). Later polls construct AMs only for
+	//     genuinely new orgs, which fall back to a per-org read, so bulk-loading on every poll would just
+	//     build a map nothing reads. Falls back to per-org reads if the bulk load fails.
+	//  2. Skip MarkConfigurationAsApplied: a fresh Alertmanager makes every config look "changed", so each
+	//     org would issue a DB write for a config that didn't actually change — a per-org write storm.
+	//     Steady-state polls only mark genuine changes, so they're unaffected.
 	timings.warmUp = moa.warmedUp.CompareAndSwap(false, true)
 	if timings.warmUp {
+		preloadStart := time.Now()
+		if fileState, err := moa.kvStore.GetAll(ctx, kvstore.AllOrganizations, KVNamespace); err != nil {
+			moa.logger.Warn("Failed to bulk-load Alertmanager file state; falling back to per-org reads", "error", err)
+		} else {
+			ctx = WithPreloadedFileState(ctx, fileState)
+		}
+		timings.preloadStateSeconds = time.Since(preloadStart).Seconds()
+
 		ctx = WithSkipMarkConfigApplied(ctx)
 	}
 

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
@@ -252,7 +252,10 @@ func TestMultiOrgAlertmanager_SyncAlertmanagersForOrgs_PhaseTimings(t *testing.T
 		require.NoError(t, err)
 		require.Equal(t, 7, timings.concurrency)
 		require.GreaterOrEqual(t, timings.loadConfigsSeconds, 0.0)
+		require.GreaterOrEqual(t, timings.preloadStateSeconds, 0.0)
 		require.GreaterOrEqual(t, timings.syncLoopSeconds, 0.0)
+		require.GreaterOrEqual(t, timings.factorySeconds, 0.0)
+		require.GreaterOrEqual(t, timings.applyConfigSeconds, 0.0)
 		require.GreaterOrEqual(t, timings.cleanupSeconds, 0.0)
 	})
 

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
@@ -248,15 +248,22 @@ func TestMultiOrgAlertmanager_SyncAlertmanagersForOrgs_PhaseTimings(t *testing.T
 	}
 
 	t.Run("reports the configured concurrency and populates timings", func(t *testing.T) {
-		timings, err := newMam(7).SyncAlertmanagersForOrgs(context.Background(), []int64{1, 2, 3})
+		mam := newMam(7)
+		timings, err := mam.SyncAlertmanagersForOrgs(context.Background(), []int64{1, 2, 3})
 		require.NoError(t, err)
 		require.Equal(t, 7, timings.concurrency)
+		require.True(t, timings.warmUp, "the first sync is the warm-up")
 		require.GreaterOrEqual(t, timings.loadConfigsSeconds, 0.0)
 		require.GreaterOrEqual(t, timings.preloadStateSeconds, 0.0)
 		require.GreaterOrEqual(t, timings.syncLoopSeconds, 0.0)
 		require.GreaterOrEqual(t, timings.factorySeconds, 0.0)
 		require.GreaterOrEqual(t, timings.applyConfigSeconds, 0.0)
 		require.GreaterOrEqual(t, timings.cleanupSeconds, 0.0)
+
+		// Only the first sync is the warm-up; subsequent syncs mark configs as applied normally.
+		timings2, err := mam.SyncAlertmanagersForOrgs(context.Background(), []int64{1, 2, 3})
+		require.NoError(t, err)
+		require.False(t, timings2.warmUp)
 	})
 
 	t.Run("floors non-positive concurrency to 1", func(t *testing.T) {

--- a/pkg/services/ngalert/tests/fakes/kvstore.go
+++ b/pkg/services/ngalert/tests/fakes/kvstore.go
@@ -101,6 +101,21 @@ func (fkv *FakeKVStore) GetAll(ctx context.Context, orgId int64, namespace strin
 	fkv.Mtx.Lock()
 	defer fkv.Mtx.Unlock()
 
+	// orgId == AllOrganizations returns the namespace's entries for every org (mirrors the real store).
+	if orgId == kvstore.AllOrganizations {
+		all := map[int64]map[string]string{}
+		for storedOrg, namespaces := range fkv.Store {
+			if values, ok := namespaces[namespace]; ok {
+				m := make(map[string]string, len(values))
+				for k, v := range values {
+					m[k] = v
+				}
+				all[storedOrg] = m
+			}
+		}
+		return all, nil
+	}
+
 	all := map[int64]map[string]string{
 		orgId: make(map[string]string),
 	}


### PR DESCRIPTION
## Summary

Cuts `grafana-x-alert-manager` startup (the `MultiOrgAlertmanager` sync) at scale. Follow-up to #128 (parallelized the per-org loop) and #129 (phase-timing observability).

**Result (prod, eu-central-1, ~2708 orgs): sync dropped from ~50s to ~7–11s.**

## How we got here (what the commits do)

This PR is the tail of an investigation; the commits reflect it:

1. **Bulk-load Alertmanager file state** — one `kvStore.GetAll(AllOrganizations)` up front instead of ~2×n per-org `kv.Get` reads, injected via context so `FileStore.FilepathFor` hydrates from memory.
   *Turned out NOT to be the bottleneck (per-org reads were cheap — bulk load is ~60ms), but it's kept: it removes ~2×n reads per restart from the shared DB.*

2. **Split the sync-loop timing** into `factory_seconds_total` vs `apply_config_seconds_total` (aggregate across workers). This localized ~99% of the loop to `ApplyConfig`, and showed it's I/O-bound (~0.34 cores).

3. **Skip `MarkConfigurationAsApplied` on the warm-up sync — the actual fix.** Tracing `ApplyConfig`:
   - Decrypt ruled out: contact-point secrets use `secrets.WithoutScope()` (global, daily-rotated) and data keys are cached, so decrypt is cache-hit CPU, not the I/O.
   - `AddAutogenConfig` ruled out: `alertingSimplifiedRouting` is off by default, so its per-org `ListNotificationSettings` read doesn't run.
   - Culprit: `MarkConfigurationAsApplied` — a **transactional DB write per org** that fires for **every** org at startup, because a fresh Alertmanager makes every config look "changed". That's ~n commit-fsync write-transactions on the shared RDS — the I/O the workers block on, and it scales with org count.

   On the first (warm-up) sync we skip that marker: those configs were already applied before the restart, so re-stamping `last_applied` for all of them is a write storm for no real change. Gated by a per-MOA `warmedUp` flag (`CompareAndSwap`) + a context flag checked in `applyAndMarkConfig`. New `warmup` field in the completion log.

## ⚠️ Behavior change for reviewer sign-off

On a pod restart, `last_applied` is no longer re-stamped for every config — it keeps the timestamp of the last **genuine** save/apply. This is safe and arguably more correct:
- Both save paths (`SaveAndApplyConfig` / `SaveAndApplyDefaultConfig`) already stamp `last_applied` at save time, so every config already has a genuine timestamp.
- The only consumer is the config-history read API (`GetAppliedAlertmanagerConfigurations`); it filters `last_applied != 0`, still satisfied — configs still show in history, just dated to when they were actually applied rather than to a pod restart.
- Steady-state syncs are unaffected (unchanged configs have `configChanged == false`, so they don't mark anyway; genuine changes still mark).

Flagging in case any out-of-repo tooling treats "last_applied bumped" as a per-instance heartbeat.

## Results

| env | orgs | before | after |
|---|---|---|---|
| prod eu-central-1 | ~2708 | ~50s | **~7–11s** |
| staging us-east-1 | 94 | `apply_config_total` 16.5s / wall 2.2s | 2.8s / 0.58s |

(There's some cold-start variance at low scale — first-touch data-key fetches — but it's a fixed small cost that's negligible against thousands of orgs.)

## Testing

- `go test -race ./pkg/services/ngalert/notifier/` — pass.
- `TestFileStore_FilepathFor_PreloadedState` — preloaded state is used without a kvstore read; absent org is a no-op.
- `TestMultiOrgAlertmanager_SyncAlertmanagersForOrgs_PhaseTimings` — reports effective concurrency, populates timings, and `warmUp` is true on the first sync / false after.