### PR TITLE
APPZ-2953 - Send alert rule identity headers (x-gf-rule-uid) on alert-eval datasource queries

### DIFF
--- a/pkg/models/headers_logzio.go
+++ b/pkg/models/headers_logzio.go
@@ -21,6 +21,9 @@ var logzioHeadersWhitelist = []string{
 	"X-Logz-Query-Context",
 	"Query-Source",
 	LogzioRequestIdHeaderName,
+	"x-gf-rule-uid",
+	"x-gf-rule-group",
+	"x-gf-rule-title",
 }
 
 func WithLogzHeaders(ctx context.Context, requestHeaders http.Header) context.Context {

--- a/pkg/models/headers_logzio_test.go
+++ b/pkg/models/headers_logzio_test.go
@@ -1,0 +1,29 @@
+package models
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDatasourceQueryHeaders(t *testing.T) {
+	logzHeaders := http.Header{}
+	logzHeaders.Set("Query-Source", "METRICS_ALERTS")
+	logzHeaders.Set("x-gf-rule-uid", "rule-abc")
+	logzHeaders.Set("x-gf-rule-group", "group-1")
+	logzHeaders.Set("x-gf-rule-title", "High CPU")
+	logzHeaders.Set("x-not-whitelisted", "should-not-forward")
+
+	lh := &LogzIoHeaders{RequestHeaders: logzHeaders}
+	out := lh.GetDatasourceQueryHeaders(http.Header{})
+
+	// Whitelisted headers (including the alert-rule identity headers) are forwarded to the datasource request.
+	require.Equal(t, "METRICS_ALERTS", out.Get("Query-Source"))
+	require.Equal(t, "rule-abc", out.Get("x-gf-rule-uid"))
+	require.Equal(t, "group-1", out.Get("x-gf-rule-group"))
+	require.Equal(t, "High CPU", out.Get("x-gf-rule-title"))
+
+	// Non-whitelisted headers are not forwarded.
+	require.Empty(t, out.Get("x-not-whitelisted"))
+}

--- a/pkg/services/ngalert/api/alerting_logzio.go
+++ b/pkg/services/ngalert/api/alerting_logzio.go
@@ -56,7 +56,7 @@ func (srv *LogzioAlertingService) RouteEvaluateAlert(c *contextmodel.ReqContext,
 			AlertRule:   evalRequest.AlertRule,
 			EvalTime:    evalRequest.EvalTime,
 			FolderTitle: evalRequest.FolderTitle,
-			LogzHeaders: srv.addLogzRequestHeaders(c, requestId),
+			LogzHeaders: srv.addLogzRequestHeaders(c, requestId, evalRequest.AlertRule),
 		}
 
 		var step = evalRequest.AlertRule.ID % 30
@@ -75,10 +75,14 @@ func (srv *LogzioAlertingService) RouteEvaluateAlert(c *contextmodel.ReqContext,
 	return response.JSON(http.StatusOK, apimodels.EvalRunsResponse{RunResults: results})
 }
 
-func (srv *LogzioAlertingService) addLogzRequestHeaders(c *contextmodel.ReqContext, requestId string) http.Header {
+func (srv *LogzioAlertingService) addLogzRequestHeaders(c *contextmodel.ReqContext, requestId string, rule ngmodels.AlertRule) http.Header {
 	requestHeaders := c.Req.Header.Clone()
 	requestHeaders.Set("Query-Source", "METRICS_ALERTS")
 	requestHeaders.Set(models.LogzioRequestIdHeaderName, requestId)
+	// Forwarded to the datasource (see logzioHeadersWhitelist) so the backend can attribute a query to its rule.
+	requestHeaders.Set("x-gf-rule-uid", rule.UID)
+	requestHeaders.Set("x-gf-rule-group", rule.RuleGroup)
+	requestHeaders.Set("x-gf-rule-title", rule.Title)
 	return requestHeaders
 }
 


### PR DESCRIPTION
## Why

When ngalert evaluates a rule, grafana-x-alert-manager makes a server-side query to the M3 datasource, reaching m3-query-service. When such a query fails downstream, m3-query-service logs the accountId and PromQL but **can't attribute the failure to a specific alert rule** — the rule UID never reaches it. ([APPZ-2953](https://logzio.atlassian.net/browse/APPZ-2953))

## What

On the outbound datasource request during alert-rule evaluation, send the rule identity as headers, reusing the existing Logz.io per-request header path that already stamps `Query-Source: METRICS_ALERTS`:

- `LogzioAlertingService.addLogzRequestHeaders` now sets `x-gf-rule-uid`, `x-gf-rule-group`, `x-gf-rule-title` from `evalRequest.AlertRule`.
- Added those three to `logzioHeadersWhitelist`, so `LogzIoHeaders.GetDatasourceQueryHeaders` forwards them onto the datasource request (the same mechanism that carries `Query-Source`).

The UID is the persisted `AlertRule.UID` (as used in the ruler API / DB), so it can be joined against our DB.

## Notes / absent cases

- Present exactly when `Query-Source=METRICS_ALERTS` (real rule evaluations).
- Absent for test/preview evaluations (ad-hoc, not persisted rules) and datasources that don't go through `GetDatasourceQueryHeaders`.
- Header keys canonicalize on the wire to `X-Gf-Rule-Uid` etc. (HTTP is case-insensitive), consistent with the existing `x-gf-*` custom headers.
- Grafana has an internal `X-Rule-Uid`, but it isn't forwarded to the datasource in this fork; we use the `x-gf-*` family for consistency.

## Testing

- `go test ./pkg/models/` — pass.
- `TestGetDatasourceQueryHeaders`: the three rule headers (and `Query-Source`) are forwarded; a non-whitelisted header is not.

[APPZ-2953]: https://logzio.atlassian.net/browse/APPZ-2953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ