### PR TITLE
APPZ-3027-improve-grafana-observability

### DIFF
--- a/pkg/cmd/grafana-server/commands/diagnostics.go
+++ b/pkg/cmd/grafana-server/commands/diagnostics.go
@@ -15,14 +15,24 @@ const (
 	profilingEnabledEnvName = "GF_DIAGNOSTICS_PROFILING_ENABLED"
 	profilingAddrEnvName    = "GF_DIAGNOSTICS_PROFILING_ADDR"
 	profilingPortEnvName    = "GF_DIAGNOSTICS_PROFILING_PORT"
-	tracingEnabledEnvName   = "GF_DIAGNOSTICS_TRACING_ENABLED"
-	tracingFileEnvName      = "GF_DIAGNOSTICS_TRACING_FILE"
+	// LOGZ.IO GRAFANA CHANGE :: APPZ-3027 Make the block profile rate opt-in
+	profilingBlockRateEnvName = "GF_DIAGNOSTICS_PROFILING_BLOCK_RATE"
+	// LOGZ.IO GRAFANA CHANGE :: End
+	tracingEnabledEnvName = "GF_DIAGNOSTICS_TRACING_ENABLED"
+	tracingFileEnvName    = "GF_DIAGNOSTICS_TRACING_FILE"
 )
 
 type profilingDiagnostics struct {
 	enabled bool
 	addr    string
 	port    uint64
+	// LOGZ.IO GRAFANA CHANGE :: APPZ-3027 blockRate is passed to runtime.SetBlockProfileRate. It is the
+	// average number of nanoseconds of blocking per sampled event, so 1 samples every blocking event and
+	// 0 disables block profiling entirely. Enabling profiling used to hardcode 1, which instruments every
+	// channel and mutex wait in the process - too expensive to leave on in production, and not needed for
+	// heap profiles, which are always sampled regardless of this setting.
+	blockRate int
+	// LOGZ.IO GRAFANA CHANGE :: End
 }
 
 func newProfilingDiagnostics(enabled bool, addr string, port uint64) *profilingDiagnostics {
@@ -30,6 +40,9 @@ func newProfilingDiagnostics(enabled bool, addr string, port uint64) *profilingD
 		enabled: enabled,
 		addr:    addr,
 		port:    port,
+		// LOGZ.IO GRAFANA CHANGE :: APPZ-3027 Off unless explicitly asked for
+		blockRate: 0,
+		// LOGZ.IO GRAFANA CHANGE :: End
 	}
 }
 
@@ -56,6 +69,17 @@ func (pd *profilingDiagnostics) overrideWithEnv() error {
 		}
 		pd.port = port
 	}
+
+	// LOGZ.IO GRAFANA CHANGE :: APPZ-3027 Make the block profile rate opt-in
+	blockRateEnv := os.Getenv(profilingBlockRateEnvName)
+	if blockRateEnv != "" {
+		blockRate, parseErr := strconv.Atoi(blockRateEnv)
+		if parseErr != nil {
+			return fmt.Errorf("failed to parse %s environment variable to integer", profilingBlockRateEnvName)
+		}
+		pd.blockRate = blockRate
+	}
+	// LOGZ.IO GRAFANA CHANGE :: End
 
 	return nil
 }
@@ -97,8 +121,14 @@ func setupProfiling(profile bool, profileAddr string, profilePort uint64) error 
 	}
 
 	if profileDiagnostics.enabled {
-		fmt.Println("diagnostics: pprof profiling enabled", "addr", profileDiagnostics.addr, "port", profileDiagnostics.port)
-		runtime.SetBlockProfileRate(1)
+		fmt.Println("diagnostics: pprof profiling enabled", "addr", profileDiagnostics.addr, "port", profileDiagnostics.port,
+			"blockRate", profileDiagnostics.blockRate) // LOGZ.IO GRAFANA CHANGE :: APPZ-3027 Report the block rate in use
+		// LOGZ.IO GRAFANA CHANGE :: APPZ-3027 Only instrument blocking events when explicitly asked to.
+		// Heap and CPU profiles do not depend on this, so leaving it off keeps enabling pprof cheap.
+		if profileDiagnostics.blockRate > 0 {
+			runtime.SetBlockProfileRate(profileDiagnostics.blockRate)
+		}
+		// LOGZ.IO GRAFANA CHANGE :: End
 		go func() {
 			// TODO: We should enable the linter and fix G114 here.
 			//	G114: Use of net/http serve function that has no support for setting timeouts (gosec)

--- a/pkg/cmd/grafana-server/commands/diagnostics_test.go
+++ b/pkg/cmd/grafana-server/commands/diagnostics_test.go
@@ -7,19 +7,33 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// LOGZ.IO GRAFANA CHANGE :: APPZ-3027 withBlockRate builds an expectation with a non-zero block rate.
+func withBlockRate(pd *profilingDiagnostics, rate int) *profilingDiagnostics {
+	pd.blockRate = rate
+	return pd
+}
+
+// LOGZ.IO GRAFANA CHANGE :: End
+
 func TestProfilingDiagnostics(t *testing.T) {
 	tcs := []struct {
-		defaults   *profilingDiagnostics
-		enabledEnv string
-		addrEnv    string
-		portEnv    string
-		expected   *profilingDiagnostics
+		defaults     *profilingDiagnostics
+		enabledEnv   string
+		addrEnv      string
+		portEnv      string
+		blockRateEnv string // LOGZ.IO GRAFANA CHANGE :: APPZ-3027
+		expected     *profilingDiagnostics
 	}{
 		{defaults: newProfilingDiagnostics(false, "localhost", 6060), enabledEnv: "", addrEnv: "", portEnv: "", expected: newProfilingDiagnostics(false, "localhost", 6060)},
 		{defaults: newProfilingDiagnostics(true, "0.0.0.0", 8080), enabledEnv: "", addrEnv: "", portEnv: "", expected: newProfilingDiagnostics(true, "0.0.0.0", 8080)},
 		{defaults: newProfilingDiagnostics(false, "", 6060), enabledEnv: "false", addrEnv: "", portEnv: "8080", expected: newProfilingDiagnostics(false, "", 8080)},
 		{defaults: newProfilingDiagnostics(false, "localhost", 6060), enabledEnv: "true", addrEnv: "0.0.0.0", portEnv: "8080", expected: newProfilingDiagnostics(true, "0.0.0.0", 8080)},
 		{defaults: newProfilingDiagnostics(false, "127.0.0.1", 6060), enabledEnv: "true", addrEnv: "", portEnv: "", expected: newProfilingDiagnostics(true, "127.0.0.1", 6060)},
+		// LOGZ.IO GRAFANA CHANGE :: APPZ-3027 The block rate defaults to 0 (off) and is only set from the env.
+		{defaults: newProfilingDiagnostics(true, "0.0.0.0", 6060), enabledEnv: "", addrEnv: "", portEnv: "", blockRateEnv: "", expected: newProfilingDiagnostics(true, "0.0.0.0", 6060)},
+		{defaults: newProfilingDiagnostics(true, "0.0.0.0", 6060), enabledEnv: "", addrEnv: "", portEnv: "", blockRateEnv: "1", expected: withBlockRate(newProfilingDiagnostics(true, "0.0.0.0", 6060), 1)},
+		{defaults: newProfilingDiagnostics(true, "0.0.0.0", 6060), enabledEnv: "", addrEnv: "", portEnv: "", blockRateEnv: "10000", expected: withBlockRate(newProfilingDiagnostics(true, "0.0.0.0", 6060), 10000)},
+		// LOGZ.IO GRAFANA CHANGE :: End
 	}
 
 	for i, tc := range tcs {
@@ -33,12 +47,30 @@ func TestProfilingDiagnostics(t *testing.T) {
 			if tc.portEnv != "" {
 				t.Setenv(profilingPortEnvName, tc.portEnv)
 			}
+			// LOGZ.IO GRAFANA CHANGE :: APPZ-3027
+			if tc.blockRateEnv != "" {
+				t.Setenv(profilingBlockRateEnvName, tc.blockRateEnv)
+			}
+			// LOGZ.IO GRAFANA CHANGE :: End
 			err := tc.defaults.overrideWithEnv()
 			assert.NoError(t, err)
 			assert.Exactly(t, tc.expected, tc.defaults)
 		})
 	}
 }
+
+// LOGZ.IO GRAFANA CHANGE :: APPZ-3027 A bad block rate must be rejected, not silently ignored.
+func TestProfilingDiagnostics_InvalidBlockRate(t *testing.T) {
+	t.Setenv(profilingBlockRateEnvName, "not-a-number")
+
+	pd := newProfilingDiagnostics(true, "0.0.0.0", 6060)
+	err := pd.overrideWithEnv()
+
+	assert.Error(t, err)
+	assert.Zero(t, pd.blockRate, "block rate stays off when the value cannot be parsed")
+}
+
+// LOGZ.IO GRAFANA CHANGE :: End
 
 func TestTracingDiagnostics(t *testing.T) {
 	tcs := []struct {

--- a/pkg/services/ngalert/metrics/scheduler.go
+++ b/pkg/services/ngalert/metrics/scheduler.go
@@ -20,6 +20,7 @@ type Scheduler struct {
 	EvalDuration                        *prometheus.HistogramVec
 	ProcessDuration                     *prometheus.HistogramVec
 	SendDuration                        *prometheus.HistogramVec
+	EvalResults                         prometheus.Histogram // LOGZ.IO GRAFANA CHANGE :: APPZ-3027 Distribution of per-evaluation result counts
 	SimpleNotificationRules             *prometheus.GaugeVec
 	GroupRules                          *prometheus.GaugeVec
 	Groups                              *prometheus.GaugeVec
@@ -60,7 +61,7 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 				Name:      "rule_evaluation_failures_total",
 				Help:      "The total number of rule evaluation failures.",
 			},
-			[]string{"org", "rule_uid"}, // LOGZ.IO GRAFANA CHANGE :: DEV-47164: Add more observability to alerting based on rule uid
+			[]string{"org"},
 		),
 		EvalDuration: promauto.With(r).NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -70,7 +71,7 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 				Help:      "The time to evaluate a rule.",
 				Buckets:   []float64{.01, .1, .5, 1, 5, 10, 15, 30, 60, 120, 180, 240, 300},
 			},
-			[]string{"org", "rule_uid"}, // LOGZ.IO GRAFANA CHANGE :: DEV-47164: Add more observability to alerting based on rule uid
+			[]string{"org"},
 		),
 		ProcessDuration: promauto.With(r).NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -78,9 +79,11 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 				Subsystem: Subsystem,
 				Name:      "rule_process_evaluation_duration_seconds",
 				Help:      "The time to process the evaluation results for a rule.",
-				Buckets:   []float64{.01, .1, .5, 1, 5, 10, 15, 30, 60, 120, 180, 240, 300},
+				// LOGZ.IO GRAFANA CHANGE :: APPZ-3027 Extended past 300s: observed state processing
+				// reaches 400-700s for high-cardinality rules, which all landed in +Inf before.
+				Buckets: []float64{.01, .1, .5, 1, 5, 10, 15, 30, 60, 120, 180, 240, 300, 600, 900, 1800},
 			},
-			[]string{"org", "rule_uid"}, // LOGZ.IO GRAFANA CHANGE :: DEV-47164: Add more observability to alerting based on rule uid
+			[]string{"org"},
 		),
 		SendDuration: promauto.With(r).NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -90,8 +93,21 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 				Help:      "The time to send the alerts to Alertmanager.",
 				Buckets:   []float64{.01, .1, .5, 1, 5, 10, 15, 30, 60, 120, 180, 240, 300},
 			},
-			[]string{"org", "rule_uid"}, // LOGZ.IO GRAFANA CHANGE :: DEV-47164: Add more observability to alerting based on rule uid
+			[]string{"org"},
 		),
+		// LOGZ.IO GRAFANA CHANGE :: APPZ-3027 The number of results per evaluation drives both the
+		// memory held during state processing and the number of alert instances produced. Unlabelled
+		// so cardinality stays fixed; see offenders.go for which rules are behind the tail.
+		EvalResults: promauto.With(r).NewHistogram(
+			prometheus.HistogramOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "rule_evaluation_results",
+				Help:      "The number of results returned by a single rule evaluation.",
+				Buckets:   []float64{1, 5, 10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000, 500000, 1000000},
+			},
+		),
+		// LOGZ.IO GRAFANA CHANGE :: End
 		SimpleNotificationRules: promauto.With(r).NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace: Namespace,
@@ -126,7 +142,9 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 				Subsystem: Subsystem,
 				Name:      "schedule_periodic_duration_seconds",
 				Help:      "The time taken to run the scheduler.",
-				Buckets:   []float64{0.1, 0.25, 0.5, 1, 2, 5, 10},
+				// LOGZ.IO GRAFANA CHANGE :: APPZ-3027 Extended past 10s: a tick routinely takes 20s+
+				// because processTick warms the whole state cache, so every observation was in +Inf.
+				Buckets: []float64{0.1, 0.25, 0.5, 1, 2, 5, 10, 15, 30, 60, 120, 300, 600},
 			},
 		),
 		SchedulableAlertRules: promauto.With(r).NewGauge(

--- a/pkg/services/ngalert/metrics/scheduler.go
+++ b/pkg/services/ngalert/metrics/scheduler.go
@@ -20,7 +20,6 @@ type Scheduler struct {
 	EvalDuration                        *prometheus.HistogramVec
 	ProcessDuration                     *prometheus.HistogramVec
 	SendDuration                        *prometheus.HistogramVec
-	EvalResults                         prometheus.Histogram // LOGZ.IO GRAFANA CHANGE :: APPZ-3027 Distribution of per-evaluation result counts
 	SimpleNotificationRules             *prometheus.GaugeVec
 	GroupRules                          *prometheus.GaugeVec
 	Groups                              *prometheus.GaugeVec
@@ -95,19 +94,6 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 			},
 			[]string{"org"},
 		),
-		// LOGZ.IO GRAFANA CHANGE :: APPZ-3027 The number of results per evaluation drives both the
-		// memory held during state processing and the number of alert instances produced. Unlabelled
-		// so cardinality stays fixed; see offenders.go for which rules are behind the tail.
-		EvalResults: promauto.With(r).NewHistogram(
-			prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Subsystem: Subsystem,
-				Name:      "rule_evaluation_results",
-				Help:      "The number of results returned by a single rule evaluation.",
-				Buckets:   []float64{1, 5, 10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000, 500000, 1000000},
-			},
-		),
-		// LOGZ.IO GRAFANA CHANGE :: End
 		SimpleNotificationRules: promauto.With(r).NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace: Namespace,

--- a/pkg/services/ngalert/schedule/offenders.go
+++ b/pkg/services/ngalert/schedule/offenders.go
@@ -1,0 +1,211 @@
+// LOGZ.IO GRAFANA CHANGE :: APPZ-3027: Replace per-rule_uid metric labels with bounded top-N offender reporting.
+//
+// Per-rule latency histograms cost one metric child per rule UID that is never
+// released when a rule is deleted, which dominated the /metrics payload while
+// still not recording the number that actually matters: how many results a
+// single evaluation produced. This reports the heaviest evaluations to the log
+// instead, at a cost bounded by the number of rules rather than by the number of
+// evaluations.
+package schedule
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/benbjohnson/clock"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+const (
+	// offenderReportInterval is how often the heaviest evaluations are logged.
+	// Draining on this interval doubles as the expiry for tracked samples, so
+	// there is no TTL to configure.
+	//
+	// The window has to be wide enough that a rule lands in most of them. The
+	// heaviest rules take minutes to process and so self-throttle to roughly one
+	// evaluation per 15 minutes, which would leave them absent from many windows if
+	// the interval were shorter.
+	offenderReportInterval = 15 * time.Minute
+
+	// offenderReportSize is how many rules are reported per ordering. The top 100
+	// rules account for ~40% of all evaluation cost, against ~20% for the top 12,
+	// so a larger report shows the shape of the distribution and surfaces a new
+	// offender well before it reaches the very top.
+	offenderReportSize = 100
+)
+
+// offender is the single heaviest evaluation observed for one alert rule within
+// the current reporting window.
+type offender struct {
+	ruleUID     string
+	orgID       int64
+	results     int
+	transitions int
+	evalDur     time.Duration
+	procDur     time.Duration
+}
+
+// offenderTracker keeps, per alert rule, the worst evaluation seen since the
+// last drain according to a single ordering.
+//
+// Keying by rule UID rather than keeping a sorted top-N slice means dedup comes
+// for free (one hot rule cannot occupy every slot), the result is an exact top-N
+// rather than one biased by arrival order, and the only sorting happens once per
+// drain. Memory is bounded by the number of rules that evaluated in the window.
+type offenderTracker struct {
+	mu    sync.Mutex
+	worse func(a, b offender) bool
+	worst map[string]offender
+	seen  int64
+}
+
+func newOffenderTracker(worse func(a, b offender) bool) *offenderTracker {
+	return &offenderTracker{worse: worse, worst: make(map[string]offender)}
+}
+
+func (t *offenderTracker) observe(s offender) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.seen++
+	if prev, ok := t.worst[s.ruleUID]; ok && !t.worse(s, prev) {
+		return
+	}
+	t.worst[s.ruleUID] = s
+}
+
+// drain returns the n worst samples and the number of evaluations observed,
+// resetting the tracker for the next window.
+func (t *offenderTracker) drain(n int) ([]offender, int64) {
+	t.mu.Lock()
+	all, seen := t.worst, t.seen
+	t.worst, t.seen = make(map[string]offender, len(all)), 0
+	t.mu.Unlock()
+
+	out := make([]offender, 0, len(all))
+	for _, o := range all {
+		out = append(out, o)
+	}
+	sort.Slice(out, func(i, j int) bool { return t.worse(out[i], out[j]) })
+	if len(out) > n {
+		out = out[:n]
+	}
+	return out, seen
+}
+
+// offenderReporter tracks the heaviest evaluations on two independent axes - the
+// number of results produced, which drives memory, and the time spent turning
+// those results into state, which drives latency - and periodically logs both.
+type offenderReporter struct {
+	byResults *offenderTracker
+	byProcDur *offenderTracker
+	size      int
+	interval  time.Duration
+	log       log.Logger
+}
+
+func newOffenderReporter(logger log.Logger, size int, interval time.Duration) *offenderReporter {
+	return &offenderReporter{
+		byResults: newOffenderTracker(func(a, b offender) bool { return a.results > b.results }),
+		byProcDur: newOffenderTracker(func(a, b offender) bool { return a.procDur > b.procDur }),
+		size:      size,
+		interval:  interval,
+		log:       logger,
+	}
+}
+
+func (r *offenderReporter) observe(s offender) {
+	if r == nil {
+		return
+	}
+	r.byResults.observe(s)
+	r.byProcDur.observe(s)
+}
+
+func (r *offenderReporter) run(ctx context.Context, c clock.Clock) {
+	if r == nil || r.interval <= 0 {
+		return
+	}
+	t := c.Ticker(r.interval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			r.report()
+		}
+	}
+}
+
+// rankedOffender is one rule's entry in a report, carrying its position on each
+// axis. A rank of 0 means the rule did not place on that axis.
+type rankedOffender struct {
+	offender
+	resultsRank int
+	procRank    int
+}
+
+// report logs the current window's heaviest evaluations and starts a new window.
+func (r *offenderReporter) report() {
+	if r == nil {
+		return
+	}
+
+	byResults, seen := r.byResults.drain(r.size)
+	byProcDur, _ := r.byProcDur.drain(r.size)
+	if seen == 0 {
+		return
+	}
+
+	// A rule that places on both axes is reported once, carrying both ranks, so
+	// the report costs at most 2*size lines and usually far fewer.
+	union := make(map[string]*rankedOffender, len(byResults)+len(byProcDur))
+	for i, o := range byResults {
+		union[o.ruleUID] = &rankedOffender{offender: o, resultsRank: i + 1}
+	}
+	for i, o := range byProcDur {
+		if e, ok := union[o.ruleUID]; ok {
+			e.procRank = i + 1
+			continue
+		}
+		union[o.ruleUID] = &rankedOffender{offender: o, procRank: i + 1}
+	}
+
+	out := make([]*rankedOffender, 0, len(union))
+	for _, e := range union {
+		out = append(out, e)
+	}
+	// Rules ranked by result count first, then those that only placed on duration.
+	rank := func(e *rankedOffender) int {
+		if e.resultsRank > 0 {
+			return e.resultsRank
+		}
+		return r.size + 1 + e.procRank
+	}
+	sort.Slice(out, func(i, j int) bool { return rank(out[i]) < rank(out[j]) })
+
+	r.log.Info("Alert rule evaluation offenders",
+		"window", r.interval,
+		"evaluations", seen,
+		"reported", len(out))
+
+	for _, e := range out {
+		r.log.Info("Alert rule offender",
+			"rule_uid", e.ruleUID,
+			"org_id", e.orgID,
+			"results", e.results,
+			"transitions", e.transitions,
+			"eval_ms", e.evalDur.Milliseconds(),
+			"process_ms", e.procDur.Milliseconds(),
+			"results_rank", e.resultsRank,
+			"process_rank", e.procRank,
+			"window_evaluations", seen)
+	}
+}
+
+// LOGZ.IO GRAFANA CHANGE :: End

--- a/pkg/services/ngalert/schedule/offenders.go
+++ b/pkg/services/ngalert/schedule/offenders.go
@@ -30,16 +30,15 @@ const (
 	// the interval were shorter.
 	offenderReportInterval = 15 * time.Minute
 
-	// offenderReportSize is how many rules are reported per ordering. The top 100
+	// offenderReportSize is how many rules are reported per dimension. The top 100
 	// rules account for ~40% of all evaluation cost, against ~20% for the top 12,
 	// so a larger report shows the shape of the distribution and surfaces a new
-	// offender well before it reaches the very top.
+	// offender before it reaches the very top.
 	offenderReportSize = 100
 )
 
-// offender is the single heaviest evaluation observed for one alert rule within
-// the current reporting window.
-type offender struct {
+// sample is the cost of one rule evaluation.
+type sample struct {
 	ruleUID     string
 	orgID       int64
 	results     int
@@ -48,81 +47,135 @@ type offender struct {
 	procDur     time.Duration
 }
 
-// offenderTracker keeps, per alert rule, the worst evaluation seen since the
-// last drain according to a single ordering.
+// offender accumulates every evaluation of one rule within the current window.
 //
-// Keying by rule UID rather than keeping a sorted top-N slice means dedup comes
-// for free (one hot rule cannot occupy every slot), the result is an exact top-N
-// rather than one biased by arrival order, and the only sorting happens once per
-// drain. Memory is bounded by the number of rules that evaluated in the window.
+// Both the max and the sum are kept for each dimension because they answer
+// different questions. The max is the worst single evaluation, so it is the risk
+// of running out of memory. The sum is rate times cost, so it is the rule's share
+// of total capacity. Averages are sum/count and are left to the reader.
+type offender struct {
+	ruleUID string
+	orgID   int64
+	count   int64
+
+	maxResults, sumResults int64
+	maxTransitions         int64
+	maxProcDur, sumProcDur time.Duration
+	maxEvalDur, sumEvalDur time.Duration
+}
+
+func (o *offender) merge(s sample) {
+	o.count++
+
+	if int64(s.results) > o.maxResults {
+		o.maxResults = int64(s.results)
+	}
+	o.sumResults += int64(s.results)
+
+	if int64(s.transitions) > o.maxTransitions {
+		o.maxTransitions = int64(s.transitions)
+	}
+
+	if s.procDur > o.maxProcDur {
+		o.maxProcDur = s.procDur
+	}
+	o.sumProcDur += s.procDur
+
+	if s.evalDur > o.maxEvalDur {
+		o.maxEvalDur = s.evalDur
+	}
+	o.sumEvalDur += s.evalDur
+}
+
+// dimension is one axis a rule can be reported for. A rule is reported if it
+// places on any dimension, so a rule that is extreme in only one way is not
+// hidden by rules that are moderately bad in every way.
+type dimension struct {
+	name  string
+	worse func(a, b *offender) bool
+}
+
+// reportDimensions are the axes rules are ranked on.
+//
+// results uses the max because one huge evaluation is what exhausts memory, even
+// if the rule is usually small. The two durations use the sum because sustained
+// cost is what decides which rule to fix first.
+//
+// Query time is ranked separately from processing time because they are different
+// problems: query time is mostly the datasource's latency and is capped by
+// evaluation_timeout, while processing time has no ceiling and is where both the
+// results and the states built from them are held in memory at once.
+var reportDimensions = []dimension{
+	{"results", func(a, b *offender) bool { return a.maxResults > b.maxResults }},
+	{"process_time", func(a, b *offender) bool { return a.sumProcDur > b.sumProcDur }},
+	{"query_time", func(a, b *offender) bool { return a.sumEvalDur > b.sumEvalDur }},
+}
+
+// offenderTracker accumulates per-rule cost for the current window.
+//
+// Keying by rule UID means a rule appears once no matter how often it evaluates,
+// memory is bounded by the number of rules rather than the number of
+// evaluations, and sorting happens once per drain instead of on every sample.
 type offenderTracker struct {
 	mu    sync.Mutex
-	worse func(a, b offender) bool
-	worst map[string]offender
+	rules map[string]*offender
 	seen  int64
 }
 
-func newOffenderTracker(worse func(a, b offender) bool) *offenderTracker {
-	return &offenderTracker{worse: worse, worst: make(map[string]offender)}
+func newOffenderTracker() *offenderTracker {
+	return &offenderTracker{rules: make(map[string]*offender)}
 }
 
-func (t *offenderTracker) observe(s offender) {
+func (t *offenderTracker) observe(s sample) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	t.seen++
-	if prev, ok := t.worst[s.ruleUID]; ok && !t.worse(s, prev) {
-		return
+	o, ok := t.rules[s.ruleUID]
+	if !ok {
+		o = &offender{ruleUID: s.ruleUID, orgID: s.orgID}
+		t.rules[s.ruleUID] = o
 	}
-	t.worst[s.ruleUID] = s
+	o.merge(s)
 }
 
-// drain returns the n worst samples and the number of evaluations observed,
-// resetting the tracker for the next window.
-func (t *offenderTracker) drain(n int) ([]offender, int64) {
+// drain returns every rule seen and the total evaluation count, then starts a new
+// window.
+func (t *offenderTracker) drain() ([]*offender, int64) {
 	t.mu.Lock()
-	all, seen := t.worst, t.seen
-	t.worst, t.seen = make(map[string]offender, len(all)), 0
+	all, seen := t.rules, t.seen
+	t.rules, t.seen = make(map[string]*offender, len(all)), 0
 	t.mu.Unlock()
 
-	out := make([]offender, 0, len(all))
+	out := make([]*offender, 0, len(all))
 	for _, o := range all {
 		out = append(out, o)
-	}
-	sort.Slice(out, func(i, j int) bool { return t.worse(out[i], out[j]) })
-	if len(out) > n {
-		out = out[:n]
 	}
 	return out, seen
 }
 
-// offenderReporter tracks the heaviest evaluations on two independent axes - the
-// number of results produced, which drives memory, and the time spent turning
-// those results into state, which drives latency - and periodically logs both.
+// offenderReporter periodically logs the heaviest rule evaluations.
 type offenderReporter struct {
-	byResults *offenderTracker
-	byProcDur *offenderTracker
-	size      int
-	interval  time.Duration
-	log       log.Logger
+	tracker  *offenderTracker
+	size     int
+	interval time.Duration
+	log      log.Logger
 }
 
 func newOffenderReporter(logger log.Logger, size int, interval time.Duration) *offenderReporter {
 	return &offenderReporter{
-		byResults: newOffenderTracker(func(a, b offender) bool { return a.results > b.results }),
-		byProcDur: newOffenderTracker(func(a, b offender) bool { return a.procDur > b.procDur }),
-		size:      size,
-		interval:  interval,
-		log:       logger,
+		tracker:  newOffenderTracker(),
+		size:     size,
+		interval: interval,
+		log:      logger,
 	}
 }
 
-func (r *offenderReporter) observe(s offender) {
+func (r *offenderReporter) observe(s sample) {
 	if r == nil {
 		return
 	}
-	r.byResults.observe(s)
-	r.byProcDur.observe(s)
+	r.tracker.observe(s)
 }
 
 func (r *offenderReporter) run(ctx context.Context, c clock.Clock) {
@@ -142,12 +195,28 @@ func (r *offenderReporter) run(ctx context.Context, c clock.Clock) {
 	}
 }
 
-// rankedOffender is one rule's entry in a report, carrying its position on each
-// axis. A rank of 0 means the rule did not place on that axis.
-type rankedOffender struct {
-	offender
-	resultsRank int
-	procRank    int
+// rank returns each reported rule and its position on every dimension it placed
+// on. A missing entry means the rule did not place on that dimension.
+func (r *offenderReporter) rank(all []*offender) map[string]map[string]int {
+	ranks := make(map[string]map[string]int)
+
+	for _, d := range reportDimensions {
+		sort.Slice(all, func(i, j int) bool { return d.worse(all[i], all[j]) })
+
+		n := r.size
+		if len(all) < n {
+			n = len(all)
+		}
+		for i := 0; i < n; i++ {
+			uid := all[i].ruleUID
+			if ranks[uid] == nil {
+				ranks[uid] = make(map[string]int, len(reportDimensions))
+			}
+			ranks[uid][d.name] = i + 1
+		}
+	}
+
+	return ranks
 }
 
 // report logs the current window's heaviest evaluations and starts a new window.
@@ -156,54 +225,62 @@ func (r *offenderReporter) report() {
 		return
 	}
 
-	byResults, seen := r.byResults.drain(r.size)
-	byProcDur, _ := r.byProcDur.drain(r.size)
-	if seen == 0 {
+	all, seen := r.tracker.drain()
+	if seen == 0 || len(all) == 0 {
 		return
 	}
 
-	// A rule that places on both axes is reported once, carrying both ranks, so
-	// the report costs at most 2*size lines and usually far fewer.
-	union := make(map[string]*rankedOffender, len(byResults)+len(byProcDur))
-	for i, o := range byResults {
-		union[o.ruleUID] = &rankedOffender{offender: o, resultsRank: i + 1}
-	}
-	for i, o := range byProcDur {
-		if e, ok := union[o.ruleUID]; ok {
-			e.procRank = i + 1
-			continue
+	ranks := r.rank(all)
+
+	reported := make([]*offender, 0, len(ranks))
+	for _, o := range all {
+		if _, ok := ranks[o.ruleUID]; ok {
+			reported = append(reported, o)
 		}
-		union[o.ruleUID] = &rankedOffender{offender: o, procRank: i + 1}
 	}
 
-	out := make([]*rankedOffender, 0, len(union))
-	for _, e := range union {
-		out = append(out, e)
-	}
-	// Rules ranked by result count first, then those that only placed on duration.
-	rank := func(e *rankedOffender) int {
-		if e.resultsRank > 0 {
-			return e.resultsRank
+	// Order by the rule's best position across dimensions so the worst offenders
+	// appear first, and break ties by UID so output is deterministic.
+	best := func(o *offender) int {
+		b := r.size + 1
+		for _, rank := range ranks[o.ruleUID] {
+			if rank < b {
+				b = rank
+			}
 		}
-		return r.size + 1 + e.procRank
+		return b
 	}
-	sort.Slice(out, func(i, j int) bool { return rank(out[i]) < rank(out[j]) })
+	sort.Slice(reported, func(i, j int) bool {
+		bi, bj := best(reported[i]), best(reported[j])
+		if bi != bj {
+			return bi < bj
+		}
+		return reported[i].ruleUID < reported[j].ruleUID
+	})
 
 	r.log.Info("Alert rule evaluation offenders",
 		"window", r.interval,
 		"evaluations", seen,
-		"reported", len(out))
+		"rules_evaluated", len(all),
+		"rules_reported", len(reported),
+		"top_n", r.size)
 
-	for _, e := range out {
+	for _, o := range reported {
+		rank := ranks[o.ruleUID]
 		r.log.Info("Alert rule offender",
-			"rule_uid", e.ruleUID,
-			"org_id", e.orgID,
-			"results", e.results,
-			"transitions", e.transitions,
-			"eval_ms", e.evalDur.Milliseconds(),
-			"process_ms", e.procDur.Milliseconds(),
-			"results_rank", e.resultsRank,
-			"process_rank", e.procRank,
+			"rule_uid", o.ruleUID,
+			"org_id", o.orgID,
+			"evaluations", o.count,
+			"max_results", o.maxResults,
+			"sum_results", o.sumResults,
+			"max_transitions", o.maxTransitions,
+			"max_process_ms", o.maxProcDur.Milliseconds(),
+			"sum_process_ms", o.sumProcDur.Milliseconds(),
+			"max_query_ms", o.maxEvalDur.Milliseconds(),
+			"sum_query_ms", o.sumEvalDur.Milliseconds(),
+			"rank_results", rank["results"],
+			"rank_process_time", rank["process_time"],
+			"rank_query_time", rank["query_time"],
 			"window_evaluations", seen)
 	}
 }

--- a/pkg/services/ngalert/schedule/offenders_test.go
+++ b/pkg/services/ngalert/schedule/offenders_test.go
@@ -10,90 +10,131 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func byResults(a, b offender) bool { return a.results > b.results }
+func TestOffender_MergeKeepsMaxAndSum(t *testing.T) {
+	tr := newOffenderTracker()
 
-func TestOffenderTracker_KeepsWorstPerRule(t *testing.T) {
-	tr := newOffenderTracker(byResults)
+	tr.observe(sample{ruleUID: "a", orgID: 7, results: 10, transitions: 2, evalDur: time.Second, procDur: 2 * time.Second})
+	tr.observe(sample{ruleUID: "a", orgID: 7, results: 900, transitions: 5, evalDur: 3 * time.Second, procDur: time.Second})
+	tr.observe(sample{ruleUID: "a", orgID: 7, results: 50, transitions: 1, evalDur: time.Second, procDur: time.Second})
 
-	// The same rule seen repeatedly must occupy exactly one slot, holding its worst
-	// sample, so a frequently evaluated rule cannot crowd out the rest of the report.
-	tr.observe(offender{ruleUID: "a", results: 10})
-	tr.observe(offender{ruleUID: "a", results: 900})
-	tr.observe(offender{ruleUID: "a", results: 50})
-	tr.observe(offender{ruleUID: "b", results: 100})
+	all, seen := tr.drain()
+	require.Len(t, all, 1, "one rule occupies one slot no matter how often it evaluates")
+	assert.EqualValues(t, 3, seen)
 
-	got, seen := tr.drain(10)
-	require.Len(t, got, 2)
-	assert.EqualValues(t, 4, seen, "every observation counts toward the denominator")
-	assert.Equal(t, "a", got[0].ruleUID)
-	assert.Equal(t, 900, got[0].results, "worst sample for the rule is retained, not the latest")
-	assert.Equal(t, "b", got[1].ruleUID)
+	o := all[0]
+	assert.EqualValues(t, 7, o.orgID)
+	assert.EqualValues(t, 3, o.count)
+	assert.EqualValues(t, 900, o.maxResults)
+	assert.EqualValues(t, 960, o.sumResults)
+	assert.EqualValues(t, 5, o.maxTransitions)
+	assert.Equal(t, 2*time.Second, o.maxProcDur)
+	assert.Equal(t, 4*time.Second, o.sumProcDur)
+	assert.Equal(t, 3*time.Second, o.maxEvalDur)
+	assert.Equal(t, 5*time.Second, o.sumEvalDur)
 }
 
-func TestOffenderTracker_ExactTopNRegardlessOfArrivalOrder(t *testing.T) {
-	// Ascending arrival is the case a threshold-based top-N slice gets wrong: early
-	// small samples set the bar and later large ones can be rejected.
-	ascending := newOffenderTracker(byResults)
-	for i := 1; i <= 500; i++ {
-		ascending.observe(offender{ruleUID: fmt.Sprintf("rule-%d", i), results: i})
+func TestOffenderReporter_RankIsExactRegardlessOfArrivalOrder(t *testing.T) {
+	// Ascending arrival is what a threshold-based top-N slice gets wrong: early
+	// small samples set the bar and later large ones get rejected.
+	rank := func(order []int) map[string]map[string]int {
+		r := newOffenderReporter(nil, 3, time.Minute)
+		for _, i := range order {
+			r.observe(sample{ruleUID: fmt.Sprintf("rule-%d", i), results: i, procDur: time.Duration(i) * time.Millisecond})
+		}
+		all, _ := r.tracker.drain()
+		return r.rank(all)
 	}
-	got, seen := ascending.drain(3)
-	require.Len(t, got, 3)
-	assert.EqualValues(t, 500, seen)
-	assert.Equal(t, []int{500, 499, 498}, []int{got[0].results, got[1].results, got[2].results})
 
-	descending := newOffenderTracker(byResults)
-	for i := 500; i >= 1; i-- {
-		descending.observe(offender{ruleUID: fmt.Sprintf("rule-%d", i), results: i})
+	asc := make([]int, 0, 500)
+	for i := 1; i <= 500; i++ {
+		asc = append(asc, i)
 	}
-	got2, _ := descending.drain(3)
-	require.Len(t, got2, 3)
-	assert.Equal(t, []int{500, 499, 498}, []int{got2[0].results, got2[1].results, got2[2].results},
-		"result must not depend on arrival order")
+	desc := make([]int, 0, 500)
+	for i := 500; i >= 1; i-- {
+		desc = append(desc, i)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		order []int
+	}{{"ascending", asc}, {"descending", desc}} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rank(tc.order)
+			require.Len(t, got, 3, "only the top 3 place")
+			assert.Equal(t, 1, got["rule-500"]["results"])
+			assert.Equal(t, 2, got["rule-499"]["results"])
+			assert.Equal(t, 3, got["rule-498"]["results"])
+		})
+	}
+}
+
+func TestOffenderReporter_ReportsRuleThatPlacesOnAnySingleDimension(t *testing.T) {
+	r := newOffenderReporter(nil, 1, time.Minute)
+
+	// Three rules, each extreme on exactly one dimension. With a top-1 per
+	// dimension all three must be reported, each ranked 1 on its own axis only.
+	r.observe(sample{ruleUID: "wide", results: 900_000, procDur: time.Millisecond, evalDur: time.Millisecond})
+	r.observe(sample{ruleUID: "slow-process", results: 1, procDur: 11 * time.Minute, evalDur: time.Millisecond})
+	r.observe(sample{ruleUID: "slow-query", results: 1, procDur: time.Millisecond, evalDur: 30 * time.Second})
+
+	all, seen := r.tracker.drain()
+	require.EqualValues(t, 3, seen)
+	ranks := r.rank(all)
+
+	require.Len(t, ranks, 3)
+	assert.Equal(t, 1, ranks["wide"]["results"])
+	assert.Zero(t, ranks["wide"]["process_time"], "did not place on process time")
+
+	assert.Equal(t, 1, ranks["slow-process"]["process_time"])
+	assert.Zero(t, ranks["slow-process"]["results"])
+
+	assert.Equal(t, 1, ranks["slow-query"]["query_time"])
+	assert.Zero(t, ranks["slow-query"]["results"])
+}
+
+func TestOffenderReporter_RanksResultsByMaxAndDurationsBySum(t *testing.T) {
+	r := newOffenderReporter(nil, 1, time.Minute)
+
+	// "spiky" has the single worst evaluation. "steady" has the larger total.
+	// Results rank on the max, so spiky wins. Durations rank on the sum, so
+	// steady wins. A rule extreme on one axis must not mask the other.
+	r.observe(sample{ruleUID: "spiky", results: 1_000, procDur: 10 * time.Second})
+	for i := 0; i < 50; i++ {
+		r.observe(sample{ruleUID: "steady", results: 100, procDur: time.Second})
+	}
+
+	all, _ := r.tracker.drain()
+	ranks := r.rank(all)
+
+	assert.Equal(t, 1, ranks["spiky"]["results"], "max results: 1000 > 100")
+	assert.Equal(t, 1, ranks["steady"]["process_time"], "sum process: 50s > 10s")
 }
 
 func TestOffenderTracker_DrainResetsWindow(t *testing.T) {
-	tr := newOffenderTracker(byResults)
-	tr.observe(offender{ruleUID: "a", results: 42})
+	tr := newOffenderTracker()
+	tr.observe(sample{ruleUID: "a", results: 42})
 
-	got, seen := tr.drain(10)
-	require.Len(t, got, 1)
+	all, seen := tr.drain()
+	require.Len(t, all, 1)
 	require.EqualValues(t, 1, seen)
 
 	// The drain interval is the only expiry mechanism, so nothing may survive it.
-	got, seen = tr.drain(10)
-	assert.Empty(t, got)
+	all, seen = tr.drain()
+	assert.Empty(t, all)
 	assert.EqualValues(t, 0, seen)
-}
-
-func TestOffenderReporter_TracksBothAxesIndependently(t *testing.T) {
-	r := newOffenderReporter(nil, 1, time.Minute)
-
-	// Heaviest by result count and slowest to process are different rules; a report
-	// limited to one entry per axis must surface both.
-	r.observe(offender{ruleUID: "wide", results: 900_000, procDur: time.Second})
-	r.observe(offender{ruleUID: "slow", results: 5, procDur: 11 * time.Minute})
-
-	byRes, seen := r.byResults.drain(1)
-	byDur, _ := r.byProcDur.drain(1)
-	require.Len(t, byRes, 1)
-	require.Len(t, byDur, 1)
-	assert.EqualValues(t, 2, seen)
-	assert.Equal(t, "wide", byRes[0].ruleUID)
-	assert.Equal(t, "slow", byDur[0].ruleUID)
 }
 
 func TestOffenderReporter_NilIsSafe(t *testing.T) {
 	// schedule structs built directly in tests leave the reporter nil.
 	var r *offenderReporter
 	assert.NotPanics(t, func() {
-		r.observe(offender{ruleUID: "a", results: 1})
+		r.observe(sample{ruleUID: "a", results: 1})
 		r.report()
 	})
 }
 
-func TestOffenderReporter_ReportEmptyWindowDoesNotPanicWithNilLogger(t *testing.T) {
-	// A window with no evaluations must return before touching the logger.
+func TestOffenderReporter_ReportEmptyWindowDoesNotTouchLogger(t *testing.T) {
+	// A window with no evaluations must return before using the nil logger.
 	r := newOffenderReporter(nil, 10, time.Minute)
 	assert.NotPanics(t, r.report)
 }

--- a/pkg/services/ngalert/schedule/offenders_test.go
+++ b/pkg/services/ngalert/schedule/offenders_test.go
@@ -1,0 +1,101 @@
+// LOGZ.IO GRAFANA CHANGE :: APPZ-3027: Tests for bounded top-N offender reporting.
+package schedule
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func byResults(a, b offender) bool { return a.results > b.results }
+
+func TestOffenderTracker_KeepsWorstPerRule(t *testing.T) {
+	tr := newOffenderTracker(byResults)
+
+	// The same rule seen repeatedly must occupy exactly one slot, holding its worst
+	// sample, so a frequently evaluated rule cannot crowd out the rest of the report.
+	tr.observe(offender{ruleUID: "a", results: 10})
+	tr.observe(offender{ruleUID: "a", results: 900})
+	tr.observe(offender{ruleUID: "a", results: 50})
+	tr.observe(offender{ruleUID: "b", results: 100})
+
+	got, seen := tr.drain(10)
+	require.Len(t, got, 2)
+	assert.EqualValues(t, 4, seen, "every observation counts toward the denominator")
+	assert.Equal(t, "a", got[0].ruleUID)
+	assert.Equal(t, 900, got[0].results, "worst sample for the rule is retained, not the latest")
+	assert.Equal(t, "b", got[1].ruleUID)
+}
+
+func TestOffenderTracker_ExactTopNRegardlessOfArrivalOrder(t *testing.T) {
+	// Ascending arrival is the case a threshold-based top-N slice gets wrong: early
+	// small samples set the bar and later large ones can be rejected.
+	ascending := newOffenderTracker(byResults)
+	for i := 1; i <= 500; i++ {
+		ascending.observe(offender{ruleUID: fmt.Sprintf("rule-%d", i), results: i})
+	}
+	got, seen := ascending.drain(3)
+	require.Len(t, got, 3)
+	assert.EqualValues(t, 500, seen)
+	assert.Equal(t, []int{500, 499, 498}, []int{got[0].results, got[1].results, got[2].results})
+
+	descending := newOffenderTracker(byResults)
+	for i := 500; i >= 1; i-- {
+		descending.observe(offender{ruleUID: fmt.Sprintf("rule-%d", i), results: i})
+	}
+	got2, _ := descending.drain(3)
+	require.Len(t, got2, 3)
+	assert.Equal(t, []int{500, 499, 498}, []int{got2[0].results, got2[1].results, got2[2].results},
+		"result must not depend on arrival order")
+}
+
+func TestOffenderTracker_DrainResetsWindow(t *testing.T) {
+	tr := newOffenderTracker(byResults)
+	tr.observe(offender{ruleUID: "a", results: 42})
+
+	got, seen := tr.drain(10)
+	require.Len(t, got, 1)
+	require.EqualValues(t, 1, seen)
+
+	// The drain interval is the only expiry mechanism, so nothing may survive it.
+	got, seen = tr.drain(10)
+	assert.Empty(t, got)
+	assert.EqualValues(t, 0, seen)
+}
+
+func TestOffenderReporter_TracksBothAxesIndependently(t *testing.T) {
+	r := newOffenderReporter(nil, 1, time.Minute)
+
+	// Heaviest by result count and slowest to process are different rules; a report
+	// limited to one entry per axis must surface both.
+	r.observe(offender{ruleUID: "wide", results: 900_000, procDur: time.Second})
+	r.observe(offender{ruleUID: "slow", results: 5, procDur: 11 * time.Minute})
+
+	byRes, seen := r.byResults.drain(1)
+	byDur, _ := r.byProcDur.drain(1)
+	require.Len(t, byRes, 1)
+	require.Len(t, byDur, 1)
+	assert.EqualValues(t, 2, seen)
+	assert.Equal(t, "wide", byRes[0].ruleUID)
+	assert.Equal(t, "slow", byDur[0].ruleUID)
+}
+
+func TestOffenderReporter_NilIsSafe(t *testing.T) {
+	// schedule structs built directly in tests leave the reporter nil.
+	var r *offenderReporter
+	assert.NotPanics(t, func() {
+		r.observe(offender{ruleUID: "a", results: 1})
+		r.report()
+	})
+}
+
+func TestOffenderReporter_ReportEmptyWindowDoesNotPanicWithNilLogger(t *testing.T) {
+	// A window with no evaluations must return before touching the logger.
+	r := newOffenderReporter(nil, 10, time.Minute)
+	assert.NotPanics(t, r.report)
+}
+
+// LOGZ.IO GRAFANA CHANGE :: End

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -527,7 +527,7 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key ngmodels.AlertR
 		// what drives both memory and state-processing time, and it was previously recorded nowhere.
 		// The histogram gives the distribution; the offender report names the rules behind the tail.
 		sch.metrics.EvalResults.Observe(float64(len(results)))
-		sch.offenders.observe(offender{
+		sch.offenders.observe(sample{
 			ruleUID:     key.UID,
 			orgID:       key.OrgID,
 			results:     len(results),

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -525,8 +525,6 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key ngmodels.AlertR
 
 		// LOGZ.IO GRAFANA CHANGE :: APPZ-3027 The number of results a single evaluation produces is
 		// what drives both memory and state-processing time, and it was previously recorded nowhere.
-		// The histogram gives the distribution; the offender report names the rules behind the tail.
-		sch.metrics.EvalResults.Observe(float64(len(results)))
 		sch.offenders.observe(sample{
 			ruleUID:     key.UID,
 			orgID:       key.OrgID,

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -102,6 +102,8 @@ type schedule struct {
 	scheduledEvalEnabled bool // LOGZ.IO GRAFANA CHANGE :: DEV-43744 Add scheduled evaluation enabled config
 
 	store *store.DBstore // LOGZ.IO GRAFANA CHANGE :: DEV-47243 Handle state cache inconsistency on eval - warm cache in scheduler as temporary solution
+
+	offenders *offenderReporter // LOGZ.IO GRAFANA CHANGE :: APPZ-3027 Report the heaviest evaluations instead of labelling metrics by rule_uid
 }
 
 // SchedulerCfg is the scheduler configuration.
@@ -149,6 +151,9 @@ func NewScheduler(cfg SchedulerCfg, stateManager *state.Manager, store *store.DB
 		tracer:                cfg.Tracer,
 		scheduledEvalEnabled:  cfg.ScheduledEvalEnabled, // LOGZ.IO GRAFANA CHANGE :: DEV-43744 Add scheduled evaluation enabled config
 		store:                 store,                    // LOGZ.IO GRAFANA CHANGE :: DEV-47243 Handle state cache inconsistency on eval - warm cache in scheduler as temporary solution
+		// LOGZ.IO GRAFANA CHANGE :: APPZ-3027 Report the heaviest evaluations instead of labelling metrics by rule_uid
+		offenders: newOffenderReporter(cfg.Log, offenderReportSize, offenderReportInterval),
+		// LOGZ.IO GRAFANA CHANGE :: End
 	}
 
 	return &sch
@@ -158,6 +163,10 @@ func (sch *schedule) Run(ctx context.Context) error {
 	sch.log.Info("Starting scheduler", "tickInterval", sch.baseInterval, "maxAttempts", sch.maxAttempts)
 	t := ticker.New(sch.clock, sch.baseInterval, sch.metrics.Ticker)
 	defer t.Stop()
+
+	// LOGZ.IO GRAFANA CHANGE :: APPZ-3027 Periodically log the heaviest evaluations
+	go sch.offenders.run(ctx, sch.clock)
+	// LOGZ.IO GRAFANA CHANGE :: End
 
 	if err := sch.schedulePeriodic(ctx, t); err != nil {
 		sch.log.Error("Failure while running the rule evaluation loop", "error", err)
@@ -404,11 +413,13 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key ngmodels.AlertR
 
 	orgID := fmt.Sprint(key.OrgID)
 	evalTotal := sch.metrics.EvalTotal.WithLabelValues(orgID)
-	// LOGZ.IO GRAFANA CHANGE :: DEV-47164: Add more observability to alerting based on rule uid
-	evalDuration := sch.metrics.EvalDuration.WithLabelValues(orgID, key.UID)
-	evalTotalFailures := sch.metrics.EvalFailures.WithLabelValues(orgID, key.UID)
-	processDuration := sch.metrics.ProcessDuration.WithLabelValues(orgID, key.UID)
-	sendDuration := sch.metrics.SendDuration.WithLabelValues(orgID, key.UID)
+	// LOGZ.IO GRAFANA CHANGE :: APPZ-3027: These were labelled by rule_uid, which created one
+	// never-released metric child per rule and dominated the /metrics payload. Per-rule attribution
+	// now comes from the bounded offender report in offenders.go instead.
+	evalDuration := sch.metrics.EvalDuration.WithLabelValues(orgID)
+	evalTotalFailures := sch.metrics.EvalFailures.WithLabelValues(orgID)
+	processDuration := sch.metrics.ProcessDuration.WithLabelValues(orgID)
+	sendDuration := sch.metrics.SendDuration.WithLabelValues(orgID)
 	// LOGZ.IO GRAFANA CHANGE :: End
 
 	notify := func(states []state.StateTransition) {
@@ -509,7 +520,22 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key ngmodels.AlertR
 			results,
 			state.GetRuleExtraLabels(logger, e.rule, e.folderTitle, !sch.disableGrafanaFolder),
 		)
-		processDuration.Observe(sch.clock.Now().Sub(start).Seconds())
+		procDur := sch.clock.Now().Sub(start)
+		processDuration.Observe(procDur.Seconds())
+
+		// LOGZ.IO GRAFANA CHANGE :: APPZ-3027 The number of results a single evaluation produces is
+		// what drives both memory and state-processing time, and it was previously recorded nowhere.
+		// The histogram gives the distribution; the offender report names the rules behind the tail.
+		sch.metrics.EvalResults.Observe(float64(len(results)))
+		sch.offenders.observe(offender{
+			ruleUID:     key.UID,
+			orgID:       key.OrgID,
+			results:     len(results),
+			transitions: len(processedStates),
+			evalDur:     dur,
+			procDur:     procDur,
+		})
+		// LOGZ.IO GRAFANA CHANGE :: End
 
 		start = sch.clock.Now()
 		alerts := state.FromStateTransitionToPostableAlerts(processedStates, sch.stateManager, sch.appURL, e.logzHeaders) // LOGZ.IO GRAFANA CHANGE :: DEV-45327: Add switch to account query param

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -461,70 +461,75 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 			})
 
 			t.Run("it reports metrics", func(t *testing.T) {
-				// LOGZ.IO GRAFANA CHANGE :: DEV-47164: Add more observability to alerting based on rule uid
+				// LOGZ.IO GRAFANA CHANGE :: APPZ-3027: These metrics are labelled by org only. Per-rule
+				// attribution comes from the offender report in offenders.go, so that rule_uid does not
+				// create an unbounded set of metric children. See offenders_test.go.
 				// duration metric has 0 values because of mocked clock that do not advance
 				expectedMetric := fmt.Sprintf(
 					`# HELP grafana_alerting_rule_evaluation_duration_seconds The time to evaluate a rule.
         	            	# TYPE grafana_alerting_rule_evaluation_duration_seconds histogram
-        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="0.01"} 1
-        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="0.1"} 1
-        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="0.5"} 1
-        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="1"} 1
-        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="5"} 1
-        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="10"} 1
-        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="15"} 1
-        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="30"} 1
-							grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="60"} 1
-							grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="120"} 1
-							grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="180"} 1
-							grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="240"} 1
-							grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="300"} 1
-        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="+Inf"} 1
-        	            	grafana_alerting_rule_evaluation_duration_seconds_sum{org="%[1]d",rule_uid="%[2]s"} 0
-        	            	grafana_alerting_rule_evaluation_duration_seconds_count{org="%[1]d",rule_uid="%[2]s"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.01"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.1"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.5"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="1"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="5"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="10"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="15"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="30"} 1
+							grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="60"} 1
+							grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="120"} 1
+							grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="180"} 1
+							grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="240"} 1
+							grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="300"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="+Inf"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_sum{org="%[1]d"} 0
+        	            	grafana_alerting_rule_evaluation_duration_seconds_count{org="%[1]d"} 1
 							# HELP grafana_alerting_rule_evaluation_failures_total The total number of rule evaluation failures.
         	            	# TYPE grafana_alerting_rule_evaluation_failures_total counter
-        	            	grafana_alerting_rule_evaluation_failures_total{org="%[1]d",rule_uid="%[2]s"} 0
+        	            	grafana_alerting_rule_evaluation_failures_total{org="%[1]d"} 0
         	            	# HELP grafana_alerting_rule_evaluations_total The total number of rule evaluations.
         	            	# TYPE grafana_alerting_rule_evaluations_total counter
         	            	grafana_alerting_rule_evaluations_total{org="%[1]d"} 1
 							# HELP grafana_alerting_rule_process_evaluation_duration_seconds The time to process the evaluation results for a rule.
 							# TYPE grafana_alerting_rule_process_evaluation_duration_seconds histogram
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="0.01"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="0.1"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="0.5"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="1"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="5"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="10"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="15"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="30"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="60"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="120"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="180"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="240"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="300"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="+Inf"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_sum{org="%[1]d",rule_uid="%[2]s"} 0
-							grafana_alerting_rule_process_evaluation_duration_seconds_count{org="%[1]d",rule_uid="%[2]s"} 1
+							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="0.01"} 1
+							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="0.1"} 1
+							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="0.5"} 1
+							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="1"} 1
+							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="5"} 1
+							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="10"} 1
+							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="15"} 1
+							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="30"} 1
+							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="60"} 1
+							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="120"} 1
+							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="180"} 1
+							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="240"} 1
+							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="300"} 1
+							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="600"} 1
+							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="900"} 1
+							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="1800"} 1
+							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="+Inf"} 1
+							grafana_alerting_rule_process_evaluation_duration_seconds_sum{org="%[1]d"} 0
+							grafana_alerting_rule_process_evaluation_duration_seconds_count{org="%[1]d"} 1
 							# HELP grafana_alerting_rule_send_alerts_duration_seconds The time to send the alerts to Alertmanager.
 							# TYPE grafana_alerting_rule_send_alerts_duration_seconds histogram
-							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="0.01"} 1
-							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="0.1"} 1
-							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="0.5"} 1
-							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="1"} 1
-							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="5"} 1
-							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="10"} 1
-							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="15"} 1
-							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="30"} 1
-							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="60"} 1
-							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="120"} 1
-							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="180"} 1
-							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="240"} 1
-							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="300"} 1
-							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="+Inf"} 1
-							grafana_alerting_rule_send_alerts_duration_seconds_sum{org="%[1]d",rule_uid="%[2]s"} 0
-							grafana_alerting_rule_send_alerts_duration_seconds_count{org="%[1]d",rule_uid="%[2]s"} 1
-				`, rule.OrgID, rule.UID)
+							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="0.01"} 1
+							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="0.1"} 1
+							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="0.5"} 1
+							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="1"} 1
+							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="5"} 1
+							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="10"} 1
+							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="15"} 1
+							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="30"} 1
+							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="60"} 1
+							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="120"} 1
+							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="180"} 1
+							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="240"} 1
+							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="300"} 1
+							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="+Inf"} 1
+							grafana_alerting_rule_send_alerts_duration_seconds_sum{org="%[1]d"} 0
+							grafana_alerting_rule_send_alerts_duration_seconds_count{org="%[1]d"} 1
+				`, rule.OrgID)
 				// LOGZ.IO GRAFANA CHANGE :: End
 
 				err := testutil.GatherAndCompare(reg, bytes.NewBufferString(expectedMetric), "grafana_alerting_rule_evaluation_duration_seconds", "grafana_alerting_rule_evaluations_total", "grafana_alerting_rule_evaluation_failures_total", "grafana_alerting_rule_process_evaluation_duration_seconds", "grafana_alerting_rule_send_alerts_duration_seconds")
@@ -692,64 +697,67 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 			expectedMetric := fmt.Sprintf(
 				`# HELP grafana_alerting_rule_evaluation_duration_seconds The time to evaluate a rule.
         	            # TYPE grafana_alerting_rule_evaluation_duration_seconds histogram
-        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="0.01"} 3
-        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="0.1"} 3
-        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="0.5"} 3
-        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="1"} 3
-        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="5"} 3
-        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="10"} 3
-        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="15"} 3
-        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="30"} 3
-						grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="60"} 3
-						grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="120"} 3
-						grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="180"} 3
-						grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="240"} 3
-						grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="300"} 3
-        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="+Inf"} 3
-        	            grafana_alerting_rule_evaluation_duration_seconds_sum{org="%[1]d",rule_uid="%[2]s"} 0
-        	            grafana_alerting_rule_evaluation_duration_seconds_count{org="%[1]d",rule_uid="%[2]s"} 3
+        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.01"} 3
+        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.1"} 3
+        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.5"} 3
+        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="1"} 3
+        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="5"} 3
+        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="10"} 3
+        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="15"} 3
+        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="30"} 3
+						grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="60"} 3
+						grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="120"} 3
+						grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="180"} 3
+						grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="240"} 3
+						grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="300"} 3
+        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="+Inf"} 3
+        	            grafana_alerting_rule_evaluation_duration_seconds_sum{org="%[1]d"} 0
+        	            grafana_alerting_rule_evaluation_duration_seconds_count{org="%[1]d"} 3
 						# HELP grafana_alerting_rule_evaluation_failures_total The total number of rule evaluation failures.
         	            # TYPE grafana_alerting_rule_evaluation_failures_total counter
-        	            grafana_alerting_rule_evaluation_failures_total{org="%[1]d",rule_uid="%[2]s"} 3
+        	            grafana_alerting_rule_evaluation_failures_total{org="%[1]d"} 3
         	            # HELP grafana_alerting_rule_evaluations_total The total number of rule evaluations.
         	            # TYPE grafana_alerting_rule_evaluations_total counter
         	            grafana_alerting_rule_evaluations_total{org="%[1]d"} 3
 						# HELP grafana_alerting_rule_process_evaluation_duration_seconds The time to process the evaluation results for a rule.
 						# TYPE grafana_alerting_rule_process_evaluation_duration_seconds histogram
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="0.01"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="0.1"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="0.5"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="1"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="5"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="10"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="15"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="30"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="60"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="120"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="180"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="240"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="300"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="+Inf"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_sum{org="%[1]d",rule_uid="%[2]s"} 0
-						grafana_alerting_rule_process_evaluation_duration_seconds_count{org="%[1]d",rule_uid="%[2]s"} 1
+						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="0.01"} 1
+						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="0.1"} 1
+						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="0.5"} 1
+						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="1"} 1
+						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="5"} 1
+						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="10"} 1
+						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="15"} 1
+						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="30"} 1
+						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="60"} 1
+						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="120"} 1
+						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="180"} 1
+						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="240"} 1
+						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="300"} 1
+						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="600"} 1
+						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="900"} 1
+						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="1800"} 1
+						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="+Inf"} 1
+						grafana_alerting_rule_process_evaluation_duration_seconds_sum{org="%[1]d"} 0
+						grafana_alerting_rule_process_evaluation_duration_seconds_count{org="%[1]d"} 1
 						# HELP grafana_alerting_rule_send_alerts_duration_seconds The time to send the alerts to Alertmanager.
 						# TYPE grafana_alerting_rule_send_alerts_duration_seconds histogram
-						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="0.01"} 1
-						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="0.1"} 1
-						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="0.5"} 1
-						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="1"} 1
-						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="5"} 1
-						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="10"} 1
-						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="15"} 1
-						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="30"} 1
-						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="60"} 1
-						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="120"} 1
-						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="180"} 1
-						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="240"} 1
-						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="300"} 1
-						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",rule_uid="%[2]s",le="+Inf"} 1
-						grafana_alerting_rule_send_alerts_duration_seconds_sum{org="%[1]d",rule_uid="%[2]s"} 0
-						grafana_alerting_rule_send_alerts_duration_seconds_count{org="%[1]d",rule_uid="%[2]s"} 1
+						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="0.01"} 1
+						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="0.1"} 1
+						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="0.5"} 1
+						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="1"} 1
+						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="5"} 1
+						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="10"} 1
+						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="15"} 1
+						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="30"} 1
+						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="60"} 1
+						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="120"} 1
+						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="180"} 1
+						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="240"} 1
+						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="300"} 1
+						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="+Inf"} 1
+						grafana_alerting_rule_send_alerts_duration_seconds_sum{org="%[1]d"} 0
+						grafana_alerting_rule_send_alerts_duration_seconds_count{org="%[1]d"} 1
 				`, rule.OrgID, rule.UID)
 			// LOGZ.IO GRAFANA CHANGE :: End
 


### PR DESCRIPTION
What                                                                                                                                                                                       
                                                                                                                                                                                           
- Dropped rule_uid from 3 histograms and 1 counter. It created a metric child per rule that was never released. /metrics goes from 49 MB / 485k lines to ~10 MB / 103k lines.              
- Added offenders.go: every 15 minutes, logs the top 100 rules by result count, state-processing time, and query time. Bounded by rule count, not evaluation count. ~150 lines per window. 
- Added max_results / sum_results — the number of results per evaluation, which was recorded nowhere and drives both memory and alert instance count.                                      
- Extended buckets on rule_process_evaluation_duration_seconds (300s → 1800s) and schedule_periodic_duration_seconds (10s → 600s). Both were saturated at +Inf.                            
- runtime.SetBlockProfileRate(1) is now opt-in via GF_DIAGNOSTICS_PROFILING_BLOCK_RATE, default 0. Heap profiles don't need it, so enabling pprof is now cheap.                            
                                                                                                                                                                                           
Logs                                                                                                                                                                                       
                                                                                                                                                                                           
message:"Alert rule offender"                                                                                                                                                              
message:"Alert rule evaluation offenders"                                                                                                                                                  
                                                                                                                                                                                           
First report lands 15 min after pod start.                                                                                                                                                 
